### PR TITLE
* [android] clear listener when activity destroy to prevent memory leak

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXEmbed.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXEmbed.java
@@ -437,14 +437,6 @@ public class WXEmbed extends WXDiv implements WXSDKInstance.OnInstanceVisibleLis
     }
   }
 
-  @Override
-  public void onActivityDestroy() {
-    super.onActivityDestroy();
-    if (getInstance() != null) {
-      getInstance().removeOnInstanceVisibleListener(this);
-    }
-  }
-
   private WXSDKInstance createInstance() {
     WXSDKInstance sdkInstance = getInstance().createNestedInstance(this);
     getInstance().addOnInstanceVisibleListener(this);
@@ -501,6 +493,9 @@ public class WXEmbed extends WXDiv implements WXSDKInstance.OnInstanceVisibleLis
       mNestedInstance = null;
     }
     src = null;
+    if (getInstance() != null) {
+      getInstance().removeOnInstanceVisibleListener(this);
+    }
   }
 
   @Override

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXEmbed.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXEmbed.java
@@ -437,6 +437,14 @@ public class WXEmbed extends WXDiv implements WXSDKInstance.OnInstanceVisibleLis
     }
   }
 
+  @Override
+  public void onActivityDestroy() {
+    super.onActivityDestroy();
+    if (getInstance() != null) {
+      getInstance().removeOnInstanceVisibleListener(this);
+    }
+  }
+
   private WXSDKInstance createInstance() {
     WXSDKInstance sdkInstance = getInstance().createNestedInstance(this);
     getInstance().addOnInstanceVisibleListener(this);


### PR DESCRIPTION
clear listener when activity destroy to prevent memory leak