### PR TITLE
Fix pos fixed failed when parent is scroller

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/WXSDKInstance.java
+++ b/android/sdk/src/main/java/com/taobao/weex/WXSDKInstance.java
@@ -1266,14 +1266,14 @@ public class WXSDKInstance implements IWXActivityStateListener,DomContext, View.
   }
 
   public void addFixedView(View fixedChild){
-    if(mRootComp instanceof WXVContainer){
-      ((WXVContainer)mRootComp).getRealView().addView(fixedChild);
+    if(mRenderContainer != null) {
+      mRenderContainer.addView(fixedChild);
     }
   }
 
   public void removeFixedView(View fixedChild){
-    if(mRootComp instanceof WXVContainer){
-      ((WXVContainer)mRootComp).getRealView().removeView(fixedChild);
+    if(mRenderContainer != null) {
+      mRenderContainer.removeView(fixedChild);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   },
   "devDependencies": {
     "xml2map": "^1.0.2",
-    "weex-wd": "^1.0.12",
+    "weex-wd": "^1.0.14",
     "macaca-utils": "^0.1.9",
     "babel-core": "^6.17.0",
     "babel-istanbul": "^0.11.0",

--- a/test/README.md
+++ b/test/README.md
@@ -4,6 +4,7 @@
 
 ## [Setup Macaca](https://macacajs.github.io/zh/environment-setup)
 
+
 ## Run 
 
 ### Test Build-in Cases

--- a/test/pages/components/scroller-fixed.we
+++ b/test/pages/components/scroller-fixed.we
@@ -1,0 +1,62 @@
+<template>
+  <scroller id="container" class="container" onscroll="onscroll">
+      <div><text>{{vp}}|{{p1}}|{{p2}}</text></div>
+    <div repeat="{{items}}" style="background-color:yellow;height:500"><text>row</text></div>
+    <div id="panel" class="fixed-panel"></div>
+    <div id="panel2" class="fixed-panel2"></div>
+  </scroller>
+</template>
+<style>
+  .container {
+    width: 750;
+  }
+  .fixed-panel {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    height: 200;
+    background-color: #ff0000;
+    width: 200;
+  }
+  .fixed-panel2 {
+    position: fixed;
+    right: 0;
+    top: 0;
+    height: 200;
+    background-color: #ff0000;
+    width: 200;
+  }
+</style>
+<script>
+    var dom = require("@weex-module/dom")
+    module.exports = {
+        data:{
+            items:[1,1,1,1,1,1,1,1],
+            height:100,
+            vp:-1,
+            p1:-1,
+            p2:-1
+        },
+        ready:function(){
+            var self = this;
+            dom.getComponentRect(this.$el('container'),function(data){
+                self.vp = data.size.height;
+            })
+        },
+        methods:{
+            onscroll:function(e){
+                var self = this;
+                dom.getComponentRect(this.$el('container'),function(data){
+                    self.vp = Math.round(data.size.height);
+                });
+                dom.getComponentRect(this.$el('panel'),function(data){
+                    self.p1 = Math.round(data.size.top+data.size.height);
+                });
+                dom.getComponentRect(this.$el('panel2'),function(data){
+                    self.p2 = data.size.top;
+                });
+                //should vp != 0 && p1 == vp && p2 ==0
+            }
+        }
+    }
+</script>

--- a/test/scripts/components/scroller-fixed.test.js
+++ b/test/scripts/components/scroller-fixed.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var _ = require('macaca-utils');
+var assert = require('chai').assert
+var wd = require('weex-wd')
+var path = require('path');
+var os = require('os');
+var util = require("../util.js");
+
+describe('scroller fixed position item ', function () {
+  this.timeout(util.getTimeoutMills());
+  var driver = util.createDriver(wd);
+
+  before(function () {
+    return util.init(driver)
+      .get('wxpage://' + util.getDeviceHost() +'/components/scroller-fixed.js')
+      .waitForElementByXPath('//scroller[1]/div[1]',util.getGETActionWaitTimeMills(),1000)
+  });
+
+  after(function () {
+      return util.quit(driver)
+  })
+
+
+  it('#1 position:fixed items', () => {
+    return driver
+    .touch('drag', {fromX:200, fromY:500, toX:200, toY: 400})
+    .sleep(2000)
+    .touch('drag', {fromX:200, fromY:400, toX:200, toY: 500})
+    .sleep(2000)
+    .elementByXPath('//scroller[1]/div[1]/text[1]')
+    .text()
+    .then((text)=>{
+        var parts = text.split("|");
+        assert.equal(parts[0],parts[1]);
+        assert.equal(parts[2],0);
+    })
+  })
+});


### PR DESCRIPTION
Fix item with 'position:fixed' scroll with parent.
The reason of this bug is 'fixed' view will add to root node's view. So when the root is 'scroller','fixed' not working.
Testcase: http://dotwe.org/weex/a281d7db58ba73ef0a143535d3703bc4