### PR TITLE
fix a typo in doc

### DIFF
--- a/doc/source/references/gesture.md
+++ b/doc/source/references/gesture.md
@@ -27,7 +27,7 @@ For now, there are four types of gestures:
   * `horizontalpan`
   * `verticalpan`
 * **Swipe**. Swipe is fired when user swipe a touch point on the screen. A serial of motion will only trigger one Swipe gesture.
-* **LongPress**. Swipe is fired when a touch point is held for 500 ms or more.
+* **LongPress**. LongPress is fired when a touch point is held for 500 ms or more.
 
 The Touch gesture and Pan is very close to each other, with following features hold:
 

--- a/doc/source/references/vue/difference-with-web.md
+++ b/doc/source/references/vue/difference-with-web.md
@@ -114,7 +114,7 @@ In addition, you should also pay attention to the following points:
 Because of the platform difference, you have to compile your source file in two different ways:
 
 + For the web, you can compile source files in any official way, such as Webpack + vue-loader or Browserify + vueify. and require the [weex-vue-render](https://www.npmjs.com/package/weex-vue-render), which is a group of Weex build-in components.
-+ For Android and iOS, we've provided [weex-loader](https://github.com/weepteam/weep-loader) to compile the `.vue` files. That is, use Webpack + weex-loader to generate the js bundle that is available for the native.
++ For Android and iOS, we've provided [weex-loader](https://github.com/weexteam/weex-loader) to compile the `.vue` files. That is, use Webpack + weex-loader to generate the js bundle that is available for the native.
 
 ### Use weex-loader
 


### PR DESCRIPTION
fix a typo in gesture reference doc about longPress
fix the weex-loader url broken in vue/difference-with-web