### PR TITLE
* [android] use a dom for destroy , avoid NPE after component destroyed.

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/dom/ImmutableDomObject.java
+++ b/android/sdk/src/main/java/com/taobao/weex/dom/ImmutableDomObject.java
@@ -208,6 +208,8 @@ import android.support.annotation.NonNull;
 
 import com.taobao.weex.dom.flex.Spacing;
 
+import static com.taobao.weex.dom.WXDomObject.DESTROYED;
+
 /**
  * Created by sospartan on 25/10/2016.
  */
@@ -227,4 +229,6 @@ public interface ImmutableDomObject {
   @NonNull Spacing getBorder();
   Object getExtra();
   String getType();
+
+  public final ImmutableDomObject DESTROYED = WXDomObject.DESTROYED;
 }

--- a/android/sdk/src/main/java/com/taobao/weex/dom/WXDomObject.java
+++ b/android/sdk/src/main/java/com/taobao/weex/dom/WXDomObject.java
@@ -240,6 +240,10 @@ public class WXDomObject extends CSSNode implements Cloneable,ImmutableDomObject
   public static final String ROOT = "_root";
   public static final String TRANSFORM = "transform";
   public static final String TRANSFORM_ORIGIN = "transformOrigin";
+  static final WXDomObject DESTROYED = new WXDomObject();
+  static{
+    DESTROYED.mRef = "_destroyed";
+  }
   private AtomicBoolean sDestroy = new AtomicBoolean();
 
   private int mViewPortWidth =750;

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
@@ -1316,7 +1316,7 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
       getInstance().removeFixedView(view);
     }
 
-    mDomObj = null;
+    mDomObj = ImmutableDomObject.DESTROYED;
     mIsDestroyed = true;
   }
 


### PR DESCRIPTION
Use a placeholder object for component's dom after destory.