### PR TITLE
fix WXWebView weak reference with delegate when WXWebView dealloc, fi…

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.m
@@ -23,7 +23,7 @@
 - (void)dealloc
 {
     if (self) {
-        self.delegate = nil;
+//        self.delegate = nil;
     }
 }
 

--- a/ios/sdk/WeexSDK/Sources/Layout/Layout.c
+++ b/ios/sdk/WeexSDK/Sources/Layout/Layout.c
@@ -700,6 +700,9 @@ static void layoutNodeImpl(css_node_t *node, float parentMaxWidth, float parentM
     float maxHeight = CSS_UNDEFINED;
     for (i = startLine; i < childCount; ++i) {
       child = node->get_child(node->context, i);
+        if (child == NULL) {
+            return;
+        }
       child->line_index = linesCount;
 
       child->next_absolute_child = NULL;

--- a/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.m
@@ -185,7 +185,7 @@ static css_node_t * rootNodeGetChild(void *context, int i)
     WXComponentManager *manager = (__bridge WXComponentManager *)(context);
     if (i == 0) {
         return manager->_rootComponent.cssNode;
-    } else if(manager->_fixedComponents.count > 0) {
+    } else if(manager->_fixedComponents.count >= i) {
         return ((WXComponent *)((manager->_fixedComponents)[i-1])).cssNode;
     }
     


### PR DESCRIPTION
…x hit reply too quickly cause view render crash

<!--

Notes: Weex will move into Apache Software Foundation (ASF) on Feb 24 2017.

Our new GitHub repo is https://github.com/apache/incubator-weex

After Feb 24 2017, we only accept pull requests from https://github.com/apache/incubator-weex

Thank you for your support.

----

注意：Weex 将于 2017-02-24 迁移至 Apache 基金会

届时我们会使用新的 GitHub 仓库：https://github.com/apache/incubator-weex 并在那里继续接受大家的 pull request。

更多详情请关注：https://github.com/weexteam/article/issues/130

感谢理解和支持

-->

<!--

It's ***RECOMMENDED*** to submit typo fix, new demo and tiny bugfix to `dev` branch. New feature and other modifications can be submitted to "domain" branch including `ios`, `android`, `jsfm`, `html5`.
    
See [Branch Strategy](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management) for more detail.

----

（请在***提交***前删除这段描述）

错别字修改、新 demo、较小的 bugfix 都可以直接提到 `dev` 分支；新需求以及任何你不确定影响面的改动，请提交到对应“领域”的分支（`ios`、`android`、`jsfm`、`html5`）。

查看完整的[分支策略 (英文)](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management)。

-->
