### PR TITLE
* [android] fix ConcurrentModificationException in list sticky map

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXScroller.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXScroller.java
@@ -277,7 +277,7 @@ public class WXScroller extends WXVContainer<ViewGroup> implements WXScrollViewL
   /**
    * Map for storing component that is sticky.
    **/
-  private Map<String, HashMap<String, WXComponent>> mStickyMap = new HashMap<>();
+  private Map<String, Map<String, WXComponent>> mStickyMap = new HashMap<>();
   private FrameLayout mRealView;
 
   private int mContentHeight = 0;
@@ -624,7 +624,7 @@ public class WXScroller extends WXVContainer<ViewGroup> implements WXScrollViewL
     return mOrientation;
   }
 
-  public Map<String, HashMap<String, WXComponent>> getStickMap() {
+  public Map<String, Map<String, WXComponent>> getStickMap() {
     return mStickyMap;
   }
 

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/helper/WXStickyHelper.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/helper/WXStickyHelper.java
@@ -209,6 +209,7 @@ import com.taobao.weex.ui.component.WXComponent;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Created by miomin on 16/7/7.
@@ -221,15 +222,15 @@ public class WXStickyHelper {
         this.scrollable = scrollable;
     }
 
-    public void bindStickStyle(WXComponent component, Map<String, HashMap<String, WXComponent>> mStickyMap) {
+    public void bindStickStyle(WXComponent component, Map<String, Map<String, WXComponent>> mStickyMap) {
         Scrollable scroller = component.getParentScroller();
         if (scroller == null) {
             return;
         }
-        HashMap<String, WXComponent> stickyMap = mStickyMap.get(scroller
+        Map<String, WXComponent> stickyMap = mStickyMap.get(scroller
                 .getRef());
         if (stickyMap == null) {
-            stickyMap = new HashMap<>();
+            stickyMap = new ConcurrentHashMap<>();
         }
         if (stickyMap.containsKey(component.getRef())) {
             return;
@@ -238,12 +239,12 @@ public class WXStickyHelper {
         mStickyMap.put(scroller.getRef(), stickyMap);
     }
 
-    public void unbindStickStyle(WXComponent component, Map<String, HashMap<String, WXComponent>> mStickyMap) {
+    public void unbindStickStyle(WXComponent component, Map<String, Map<String, WXComponent>> mStickyMap) {
         Scrollable scroller = component.getParentScroller();
         if (scroller == null) {
             return;
         }
-        HashMap<String, WXComponent> stickyMap = mStickyMap.get(scroller
+        Map<String, WXComponent> stickyMap = mStickyMap.get(scroller
                 .getRef());
         if (stickyMap == null) {
             return;

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/list/BasicListComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/list/BasicListComponent.java
@@ -293,7 +293,7 @@ public abstract class BasicListComponent<T extends ViewGroup & ListComponentView
   /**
    * Map for storing component that is sticky.
    **/
-  private Map<String, HashMap<String, WXComponent>> mStickyMap = new HashMap<>();
+  private Map<String, Map<String, WXComponent>> mStickyMap = new HashMap<>();
   private WXStickyHelper stickyHelper;
 
 
@@ -651,7 +651,7 @@ public abstract class BasicListComponent<T extends ViewGroup & ListComponentView
     if (mStickyMap == null || bounceRecyclerView == null) {
       return;
     }
-    HashMap<String, WXComponent> stickyMap = mStickyMap.get(getRef());
+    Map<String, WXComponent> stickyMap = mStickyMap.get(getRef());
     if (stickyMap == null) {
       return;
     }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/WXScrollView.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/WXScrollView.java
@@ -548,11 +548,11 @@ public class WXScrollView extends ScrollView implements Callback, IWXScroller,
     }
   }
 
-  private View procSticky(Map<String, HashMap<String, WXComponent>> mStickyMap) {
+  private View procSticky(Map<String, Map<String, WXComponent>> mStickyMap) {
     if (mStickyMap == null) {
       return null;
     }
-    HashMap<String, WXComponent> stickyMap = mStickyMap.get(mWAScroller.getRef());
+    Map<String, WXComponent> stickyMap = mStickyMap.get(mWAScroller.getRef());
     if (stickyMap == null) {
       return null;
     }


### PR DESCRIPTION
```
java.util.ConcurrentModificationException
at java.util.HashMap$HashIterator.nextEntry(HashMap.java:806)
at java.util.HashMap$EntryIterator.next(HashMap.java:843)
at java.util.HashMap$EntryIterator.next(HashMap.java:841)
at com.taobao.weex.ui.component.list.BasicListComponent.(BasicListComponent.java:618)
at com.taobao.weex.ui.view.listview.adapter.WXRecyclerViewOnScrollListener.(WXRecyclerViewOnScrollListener.java:270)
at android.support.v7.widget.RecyclerView.(RecyclerView.java:3954)
at android.support.v7.widget.RecyclerView.(RecyclerView.java:3115)
at android.support.v7.widget.RecyclerView.(RecyclerView.java:2917)
```

@YorkShen 