### PR TITLE
[html5] fix vertical/horizontal scroll bug

### DIFF
--- a/html5/render/browser/extend/components/scrollable/scroll.js
+++ b/html5/render/browser/extend/components/scrollable/scroll.js
@@ -235,10 +235,10 @@ function Scroll(element, options) {
   this.viewport.addEventListener('panend', panendHandler, false)
 
   if (options.isPrevent) {
-    this.viewport.addEventListener('touchstart', function (e) {
-      panning = true
+    this.viewport.addEventListener('panstart', function (e) {
+      panning = isEnabled(e)
     }, false)
-    that.viewport.addEventListener('touchend', function (e) {
+    that.viewport.addEventListener('panend', function (e) {
       panning = false
     }, false)
   }


### PR DESCRIPTION
the scroller component prevents global `touchmove` event by default, so we can't scroll the whole page vertically when set `scroll-direction` to `horizontal` which we would rather not see.

I try to  judge whether it is horizontal or vertical  to choose whether to prevent the `touchmove` event.

<!--

Notes: Weex will move into Apache Software Foundation (ASF) on Feb 24 2017.

Our new GitHub repo is https://github.com/apache/incubator-weex

After Feb 24 2017, we only accept pull requests from https://github.com/apache/incubator-weex

Thank you for your support.

----

注意：Weex 将于 2017-02-24 迁移至 Apache 基金会

届时我们会使用新的 GitHub 仓库：https://github.com/apache/incubator-weex 并在那里继续接受大家的 pull request。

更多详情请关注：https://github.com/weexteam/article/issues/130

感谢理解和支持

-->

<!--

It's ***RECOMMENDED*** to submit typo fix, new demo and tiny bugfix to `dev` branch. New feature and other modifications can be submitted to "domain" branch including `ios`, `android`, `jsfm`, `html5`.
    
See [Branch Strategy](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management) for more detail.

----

（请在***提交***前删除这段描述）

错别字修改、新 demo、较小的 bugfix 都可以直接提到 `dev` 分支；新需求以及任何你不确定影响面的改动，请提交到对应“领域”的分支（`ios`、`android`、`jsfm`、`html5`）。

查看完整的[分支策略 (英文)](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management)。

-->
