### PR TITLE
* [ios] Fix issue that [view setTransform:] not working after animation

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Module/WXAnimationModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXAnimationModule.m
@@ -89,6 +89,12 @@
 
 - (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag
 {
+    if (!_animationInfo.target) {
+        return;
+    }
+    
+    [_animationInfo.target.layer removeAllAnimations];
+    
     if (_finishBlock) {
         _finishBlock(flag);
     }


### PR DESCRIPTION
  * all CABasicAnimaitions should be removed when animation stops, otherwise it will affect view or layer's transform property
  * test demo: http://dotwe.org/weex/6a0695ca46f6abfe9638eb391aac729c

