### PR TITLE
 [android] remove special set layout parameter in baserefesh

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXBaseRefresh.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXBaseRefresh.java
@@ -236,16 +236,6 @@ public class WXBaseRefresh extends WXVContainer<WXFrameLayout> {
   }
 
   @Override
-  protected void setHostLayoutParams(WXFrameLayout host, int width, int height, int left, int right, int top, int bottom) {
-    if (getParent() instanceof Scrollable) {
-      //do nothing
-      return;
-    }else{
-      super.setHostLayoutParams(host, width, height, left, right, top, bottom);
-    }
-  }
-
-  @Override
   public void addChild(WXComponent child, int index) {
     super.addChild(child, index);
     this.checkLoadingIndicator(child);


### PR DESCRIPTION
Layout is ignore is refresh component (both WXRefresh and WXLoading), when its parent is scrollable component. That will cause style do not working in these component.
Testcase: http://dotwe.org/weex/58c9fbbda7ddb368631602c1595a717b