### PR TITLE
+ [ios] textarea add maxlength ,because android textarea has this attributes

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXEditComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXEditComponent.m
@@ -348,7 +348,7 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
     }
     if (attributes[@"value"]) {
         _value = [WXConvert NSString:attributes[@"value"]]?:@"";
-        if (_maxLength && [_value length] > [_maxLength integerValue]&& [_maxLength integerValue]> 0) {
+        if (_maxLength && [_value length] > [_maxLength integerValue]&& [_maxLength integerValue] >= 0) {
             _value = [_value substringToIndex:([_maxLength integerValue])];
         }
         [self setText:_value];

--- a/ios/sdk/WeexSDK/Sources/Component/WXEditComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXEditComponent.m
@@ -607,6 +607,15 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
             [self fireEvent:@"return" params:@{@"value":[textView text],@"returnKeyType":typeStr} domChanges:@{@"attrs":@{@"value":[textView text]}}];
         }
     }
+    
+    if (_maxLength) {
+        NSUInteger oldLength = [textView.text length];
+        NSUInteger replacementLength = [text length];
+        NSUInteger rangeLength = range.length;
+        NSUInteger newLength = oldLength - rangeLength + replacementLength;
+        return newLength <= [_maxLength integerValue] ;
+    }
+    
     return YES;
 }
 

--- a/ios/sdk/WeexSDK/Sources/Component/WXEditComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXEditComponent.m
@@ -348,6 +348,9 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
     }
     if (attributes[@"value"]) {
         _value = [WXConvert NSString:attributes[@"value"]]?:@"";
+        if (_maxLength && [_value length] > [_maxLength integerValue]&& [_maxLength integerValue]> 0) {
+            _value = [_value substringToIndex:([_maxLength integerValue])];
+        }
         [self setText:_value];
     }
     if (attributes[@"returnKeyType"]) {

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "weex-components": "^0.2.0",
     "weex-loader": "^0.4.0",
     "weex-vdom-tester": "^0.2.0",
-    "weex-wd": "^1.0.14",
+    "weex-wd": "^1.0.17",
     "wwp": "^0.3.5",
     "xml2map": "^1.0.2"
   }

--- a/test/pages/components/textarea-maxlength.vue
+++ b/test/pages/components/textarea-maxlength.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="wrapper">
+    <text style="font-size:30">test textarea maxlenght</text>
+    <textarea id="textarea" class="textarea" value="" maxlength=4 @input="oninput" @change="onchange" ></textarea>
+  </div>
+</template>
+<script>
+  const modal = weex.requireModule('modal')
+  export default {
+    methods: {
+      oninput (event) {
+        console.log('oninput:', event.value)
+        modal.toast({
+          message: `oninput: ${event.value}`,
+          duration: 0.8
+        })
+      },
+      onchange (event) {
+        console.log('onchange:', event.value)
+        modal.toast({
+          message: `onchange: ${event.value}`,
+          duration: 0.8
+        })
+      },
+    }
+  }
+</script>
+<style>
+  .textarea {
+    font-size: 50px;
+    width: 650px;
+    margin-top: 50px;
+    margin-left: 50px;
+    padding-top: 20px;
+    padding-bottom: 20px;
+    padding-left: 20px;
+    padding-right: 20px;
+    color: #666666;
+    border-width: 2px;
+    border-style: solid;
+    border-color: #41B883;
+    maxlength:10;
+  }
+</style>

--- a/test/pages/components/textarea-maxlength.vue
+++ b/test/pages/components/textarea-maxlength.vue
@@ -1,14 +1,20 @@
 <template>
   <div class="wrapper">
-    <text style="font-size:30">test textarea maxlenght</text>
+    <text style="font-size:30">{{value}}</text>
     <textarea id="textarea" class="textarea" value="" autofocus="true" maxlength=4 @input="oninput" @change="onchange" ></textarea>
   </div>
 </template>
 <script>
   const modal = weex.requireModule('modal')
   export default {
+    data () {
+      return {
+        value:'1'
+      }
+    },
     methods: {
       oninput (event) {
+        this.value = event.value
         console.log('oninput:', event.value)
         modal.toast({
           message: `oninput: ${event.value}`,

--- a/test/pages/components/textarea-maxlength.vue
+++ b/test/pages/components/textarea-maxlength.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="wrapper">
     <text style="font-size:30">test textarea maxlenght</text>
-    <textarea id="textarea" class="textarea" value="" maxlength=4 @input="oninput" @change="onchange" ></textarea>
+    <textarea id="textarea" class="textarea" value="" autofocus="true" maxlength=4 @input="oninput" @change="onchange" ></textarea>
   </div>
 </template>
 <script>

--- a/test/scripts/components/textarea-maxlength.test.js
+++ b/test/scripts/components/textarea-maxlength.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var _ = require('macaca-utils');
+var assert = require('chai').assert
+var wd = require('weex-wd')
+var path = require('path');
+var os = require('os');
+var util = require("../util.js");
+
+describe('textarea maxlength vue test2 ', function () {
+  this.timeout(util.getTimeoutMills());
+  var driver = util.createDriver(wd);
+
+  before(function () {
+    return util.init(driver)
+      .get('wxpage://' + util.getDeviceHost() +'/components/textarea-maxlength.js')
+      .waitForElementByXPath('//div/text[1]',util.getGETActionWaitTimeMills(),1000)
+  });
+
+  after(function () {
+      return util.quit(driver)
+  })
+
+  it('#1 textarea maxlenght', () => {
+    return driver
+      .waitForElementByXPath('//div/textarea')
+      .sendKeys('12345678')
+      .elementByXPath('//div/textarea')
+      .text()
+      .then((text)=>{
+      assert.equal(text,'1234')
+     })
+  })
+
+});

--- a/test/scripts/components/textarea-maxlength.test.js
+++ b/test/scripts/components/textarea-maxlength.test.js
@@ -25,7 +25,8 @@ describe('textarea maxlength vue test2 ', function () {
     return driver
       .waitForElementByXPath('//div/textarea')
       .sendKeys('12345678')
-      .elementByXPath('//div/textarea')
+      .sleep(2000)
+      .elementByXPath('//div/text[1]')
       .text()
       .then((text)=>{
       assert.equal(text,'1234')


### PR DESCRIPTION
-  textarea add maxlength ,because android textarea has this attributes
- demo
```html
<template>
  <div class="wrapper">
    <textarea class="textarea" maxlength=10 @input="oninput" @change="onchange" @focus="onfocus" @blur="onblur"></textarea>
  </div>
</template>
<script>
  const modal = weex.requireModule('modal')
  export default {
    methods: {
      oninput (event) {
        console.log('oninput:', event.value)
        modal.toast({
          message: `oninput: ${event.value}`,
          duration: 0.8
        })
      },
      onchange (event) {
        console.log('onchange:', event.value)
        modal.toast({
          message: `onchange: ${event.value}`,
          duration: 0.8
        })
      },
      onfocus (event) {
        console.log('onfocus:', event.value)
        modal.toast({
          message: `onfocus: ${event.value}`,
          duration: 0.8
        })
      },
      onblur (event) {
        console.log('onblur:', event.value)
        modal.toast({
          message: `input blur: ${event.value}`,
          duration: 0.8
        })
      }
    }
  }
</script>
<style>
  .textarea {
    font-size: 50px;
    width: 650px;
    margin-top: 50px;
    margin-left: 50px;
    padding-top: 20px;
    padding-bottom: 20px;
    padding-left: 20px;
    padding-right: 20px;
    color: #666666;
    border-width: 2px;
    border-style: solid;
    border-color: #41B883;
    maxlength:10;
  }
</style>
```