### PR TITLE
spelling mistake

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Engine/WXSDKError.h
+++ b/ios/sdk/WeexSDK/Sources/Engine/WXSDKError.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "WXSDkInstance.h"
+#import "WXSDKInstance.h"
 
 typedef NS_ENUM(int, WXSDKErrCode)
 {


### PR DESCRIPTION

[ios] fix wrong spelling caused compile error on Xcode version 8.2.1(8C1002)