### PR TITLE
* [Android] refactor animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,5 @@
 
 ### Changed
 - [android]Move DOM and render to seperate Action Object
+- [android]Move Animation(animation module and css style) to seperate Action Object
+- [android]Reserve `transformOrigin`'s last time state.

--- a/android/sdk/src/main/java/com/taobao/weex/dom/DOMActionContextImpl.java
+++ b/android/sdk/src/main/java/com/taobao/weex/dom/DOMActionContextImpl.java
@@ -204,15 +204,13 @@
  */
 package com.taobao.weex.dom;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Pair;
 
-import com.alibaba.fastjson.JSONObject;
 import com.taobao.weex.WXEnvironment;
 import com.taobao.weex.WXSDKInstance;
 import com.taobao.weex.WXSDKManager;
+import com.taobao.weex.dom.action.Actions;
 import com.taobao.weex.dom.flex.CSSLayoutContext;
 import com.taobao.weex.ui.IWXRenderTask;
 import com.taobao.weex.ui.WXRenderManager;
@@ -460,21 +458,11 @@ class DOMActionContextImpl implements DOMActionContext {
   }
 
   private void parseAnimation() {
-    for(final Pair<String, Map<String, Object>> pair:animations) {
+    for (final Pair<String, Map<String, Object>> pair : animations) {
       if (!TextUtils.isEmpty(pair.first)) {
         final WXAnimationBean animationBean = createAnimationBean(pair.first, pair.second);
         if (animationBean != null) {
-          mNormalTasks.add(new IWXRenderTask() {
-            @Override
-            public void execute() {
-              mWXRenderManager.startAnimation(mInstanceId, pair.first, animationBean, null);
-            }
-
-            @Override
-            public String toString() {
-              return "startAnimationByStyle";
-            }
-          });
+          postRenderTask(Actions.getAnimationAction(pair.first, animationBean));
         }
       }
     }
@@ -518,32 +506,6 @@ class DOMActionContextImpl implements DOMActionContext {
       for (int i = 0; i < count; ++i) {
         updateDomObj(container.getChild(i));
       }
-    }
-  }
-
-  void startAnimation(@NonNull final String ref, @NonNull String animation,
-                      @Nullable final String callBack){
-    if (mDestroy) {
-      return;
-    }
-    WXDomObject domObject = mRegistry.get(ref);
-    if (domObject == null) {
-      return;
-    }
-    final WXAnimationBean animationBean=createAnimationBean(ref, animation);
-    if(animationBean!=null) {
-      mNormalTasks.add(new IWXRenderTask() {
-        @Override
-        public void execute() {
-          mWXRenderManager.startAnimation(mInstanceId, ref, animationBean, callBack);
-        }
-
-        @Override
-        public String toString() {
-          return "startAnimationByCall";
-        }
-      });
-      mDirty=true;
     }
   }
 
@@ -592,24 +554,6 @@ class DOMActionContextImpl implements DOMActionContext {
   @Override
   public WXDomObject getDomByRef(String ref) {
     return mRegistry.get(ref);
-  }
-
-  private WXAnimationBean createAnimationBean(String ref, String animation){
-    try {
-      WXAnimationBean animationBean =
-          JSONObject.parseObject(animation, WXAnimationBean.class);
-      if (animationBean != null && animationBean.styles != null) {
-        WXDomObject domObject=mRegistry.get(ref);
-        int width=(int)domObject.getLayoutWidth();
-        int height=(int)domObject.getLayoutHeight();
-        animationBean.styles.init(animationBean.styles.transformOrigin,
-                                  animationBean.styles.transform,width,height,WXSDKManager.getInstance().getSDKInstance(mInstanceId).getInstanceViewPortWidth());
-      }
-      return animationBean;
-    } catch (RuntimeException e) {
-      WXLogUtils.e("", e);
-      return null;
-    }
   }
 
   private WXAnimationBean createAnimationBean(String ref,Map<String, Object> style){

--- a/android/sdk/src/main/java/com/taobao/weex/dom/WXDomHandler.java
+++ b/android/sdk/src/main/java/com/taobao/weex/dom/WXDomHandler.java
@@ -207,9 +207,7 @@ package com.taobao.weex.dom;
 import android.os.Handler;
 import android.os.Message;
 
-import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
-import com.taobao.weex.bridge.JSCallback;
 import com.taobao.weex.dom.action.Actions;
 
 /**
@@ -255,12 +253,6 @@ public class WXDomHandler implements Handler.Callback {
             (JSONObject) task.args.get(1),
             task.args.size() > 2 && (boolean) task.args.get(2)),false);
         break;
-      case MsgType.WX_ANIMATION:
-        mWXDomManager.startAnimation(task.instanceId,
-                                     (String) task.args.get(0),
-                                     (String) task.args.get(1),
-                                     (String) task.args.get(2));
-        break;
       case MsgType.WX_DOM_BATCH:
 
         mWXDomManager.batch();
@@ -299,6 +291,7 @@ public class WXDomHandler implements Handler.Callback {
     public static final int WX_DOM_REFRESH_FINISH = 0x0a;
     @Deprecated
     public static final int WX_DOM_UPDATE_FINISH = 0x0b;
+    @Deprecated
     public static final int WX_ANIMATION=0xc;
     @Deprecated
     public static final int WX_DOM_ADD_RULE=0xd;

--- a/android/sdk/src/main/java/com/taobao/weex/dom/action/Actions.java
+++ b/android/sdk/src/main/java/com/taobao/weex/dom/action/Actions.java
@@ -204,10 +204,30 @@
  */
 package com.taobao.weex.dom.action;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import com.taobao.weex.dom.DOMAction;
-import static com.taobao.weex.dom.WXDomModule.*;
+import com.taobao.weex.dom.RenderAction;
+import com.taobao.weex.ui.animation.WXAnimationBean;
+
+import static com.taobao.weex.dom.WXDomModule.ADD_ELEMENT;
+import static com.taobao.weex.dom.WXDomModule.ADD_EVENT;
+import static com.taobao.weex.dom.WXDomModule.ADD_RULE;
+import static com.taobao.weex.dom.WXDomModule.CREATE_BODY;
+import static com.taobao.weex.dom.WXDomModule.CREATE_FINISH;
+import static com.taobao.weex.dom.WXDomModule.GET_COMPONENT_RECT;
+import static com.taobao.weex.dom.WXDomModule.INVOKE_METHOD;
+import static com.taobao.weex.dom.WXDomModule.MOVE_ELEMENT;
+import static com.taobao.weex.dom.WXDomModule.REFRESH_FINISH;
+import static com.taobao.weex.dom.WXDomModule.REMOVE_ELEMENT;
+import static com.taobao.weex.dom.WXDomModule.REMOVE_EVENT;
+import static com.taobao.weex.dom.WXDomModule.SCROLL_TO_ELEMENT;
+import static com.taobao.weex.dom.WXDomModule.UPDATE_ATTRS;
+import static com.taobao.weex.dom.WXDomModule.UPDATE_FINISH;
+import static com.taobao.weex.dom.WXDomModule.UPDATE_STYLE;
 
 /**
  * Created by sospartan on 01/03/2017.
@@ -310,5 +330,21 @@ public class Actions {
 
   public static DOMAction getAddEvent(String ref, String type) {
     return new AddEventAction(ref,type);
+  }
+
+  public static DOMAction getAnimationAction(@NonNull final String ref, @NonNull String animation,
+                                             @Nullable final String callBack){
+    return new AnimationAction(ref, animation, callBack);
+  }
+
+  public static RenderAction getAnimationAction(@NonNull String ref,
+                                                @NonNull final WXAnimationBean animationBean){
+    return new AnimationAction(ref, animationBean);
+  }
+
+  public static RenderAction getAnimationAction(@NonNull String ref,
+                                                @NonNull final WXAnimationBean animationBean,
+                                                @Nullable String callback){
+    return new AnimationAction(ref, animationBean, callback);
   }
 }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/RenderActionContextImpl.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/RenderActionContextImpl.java
@@ -289,10 +289,6 @@ class RenderActionContextImpl implements RenderActionContext {
     return mRegistry.get(ref);
   }
 
-  void startAnimation(@NonNull String ref, @NonNull WXAnimationBean animationBean, @Nullable String callBack) {
-    WXAnimationModule.startAnimation(mWXSDKInstance, mRegistry.get(ref), animationBean, callBack);
-  }
-
   public void registerComponent(String ref, WXComponent comp) {
     mRegistry.put(ref,comp);
   }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/WXRenderManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/WXRenderManager.java
@@ -204,7 +204,6 @@
  */
 package com.taobao.weex.ui;
 
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
@@ -214,7 +213,6 @@ import com.taobao.weex.common.WXThread;
 import com.taobao.weex.dom.RenderAction;
 import com.taobao.weex.dom.RenderActionContext;
 import com.taobao.weex.dom.WXDomObject;
-import com.taobao.weex.ui.animation.WXAnimationBean;
 import com.taobao.weex.ui.component.WXComponent;
 import com.taobao.weex.utils.WXUtils;
 
@@ -323,16 +321,6 @@ public class WXRenderManager {
       return;
     }
     statement.setExtra(ref, extra);
-  }
-
-  public void startAnimation(String instanceId, @NonNull String ref,
-                             @NonNull WXAnimationBean animationBean, @Nullable String
-      callBack) {
-    RenderActionContextImpl statement = mRegistries.get(instanceId);
-    if (statement == null) {
-      return;
-    }
-    statement.startAnimation(ref, animationBean, callBack);
   }
 
   public List<WXSDKInstance> getAllInstances() {

--- a/android/sdk/src/main/java/com/taobao/weex/ui/animation/DimensionUpdateListener.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/animation/DimensionUpdateListener.java
@@ -220,16 +220,16 @@ public class DimensionUpdateListener implements ValueAnimator.AnimatorUpdateList
   private Pair<Integer, Integer> height;
   private IntEvaluator intEvaluator;
 
-  DimensionUpdateListener(@NonNull View view) {
+  public DimensionUpdateListener(@NonNull View view) {
     this.view = view;
     intEvaluator = new IntEvaluator();
   }
 
-  void setWidth(int from, int to) {
+  public void setWidth(int from, int to) {
     width = new Pair<>(from, to);
   }
 
-  void setHeight(int from, int to) {
+  public void setHeight(int from, int to) {
     height = new Pair<>(from, to);
   }
 

--- a/android/sdk/src/main/java/com/taobao/weex/ui/animation/WXAnimationBean.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/animation/WXAnimationBean.java
@@ -411,8 +411,7 @@ public class WXAnimationBean {
           }
         }
       }
-      return parsePivot(Arrays.asList(WXAnimationBean.Style.CENTER,
-                                      WXAnimationBean.Style.CENTER), width, height,viewportW);
+      return null;
     }
 
     private static Pair<Float, Float> parsePivot(@NonNull List<String> list, int width, int height,int viewportW) {
@@ -469,7 +468,7 @@ public class WXAnimationBean {
       return defaultMap;
     }
 
-    public Pair<Float, Float> getPivot() {
+    public @Nullable Pair<Float, Float> getPivot() {
       return pivot;
     }
 

--- a/android/sdk/src/main/java/com/taobao/weex/ui/animation/WXAnimationModule.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/animation/WXAnimationModule.java
@@ -204,220 +204,47 @@
  */
 package com.taobao.weex.ui.animation;
 
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
-import android.animation.ArgbEvaluator;
-import android.animation.ObjectAnimator;
-import android.animation.PropertyValuesHolder;
-import android.graphics.drawable.ColorDrawable;
-import android.os.Build;
-import android.os.Message;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.view.animation.PathInterpolatorCompat;
 import android.text.TextUtils;
-import android.util.Pair;
-import android.view.View;
-import android.view.ViewGroup;
-import android.view.animation.AccelerateDecelerateInterpolator;
-import android.view.animation.AccelerateInterpolator;
-import android.view.animation.DecelerateInterpolator;
-import android.view.animation.Interpolator;
-import android.view.animation.LinearInterpolator;
 
 import com.taobao.weex.WXSDKInstance;
 import com.taobao.weex.WXSDKManager;
 import com.taobao.weex.annotation.JSMethod;
 import com.taobao.weex.common.WXModule;
+import com.taobao.weex.dom.DOMAction;
+import com.taobao.weex.dom.RenderAction;
 import com.taobao.weex.dom.WXDomHandler;
-import com.taobao.weex.dom.WXDomTask;
+import com.taobao.weex.dom.action.Actions;
 import com.taobao.weex.ui.component.WXComponent;
-import com.taobao.weex.ui.view.border.BorderDrawable;
-import com.taobao.weex.utils.SingleFunctionParser;
-import com.taobao.weex.utils.WXLogUtils;
-import com.taobao.weex.utils.WXResourceUtils;
-import com.taobao.weex.utils.WXUtils;
-import com.taobao.weex.utils.WXViewUtils;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import static com.taobao.weex.dom.action.Actions.getAnimationAction;
 
 public class WXAnimationModule extends WXModule {
 
   @JSMethod
   public void transition(@Nullable String ref, @Nullable String animation, @Nullable String callBack) {
-    if(!TextUtils.isEmpty(ref)&&!TextUtils.isEmpty(animation) && mWXSDKInstance!=null) {
-      Message msg = Message.obtain();
-      WXDomTask task = new WXDomTask();
-      task.instanceId = mWXSDKInstance.getInstanceId();
-      task.args = new ArrayList<>();
-      task.args.add(ref);
-      task.args.add(animation);
-      task.args.add(callBack);
-      msg.what = WXDomHandler.MsgType.WX_ANIMATION;
-      msg.obj = task;
+    if (!TextUtils.isEmpty(ref) && !TextUtils.isEmpty(animation) && mWXSDKInstance != null) {
+      DOMAction animationActions = getAnimationAction(ref, animation, callBack);
       //Due to animation module rely on the result of the css-layout and the batch mechanism of
       //css-layout, the animation.transition must be delayed the batch time.
-      WXSDKManager.getInstance().getWXDomManager().sendMessageDelayed(msg, WXDomHandler.DELAY_TIME);
+      WXSDKManager.getInstance().getWXDomManager().postActionDelay(mWXSDKInstance.getInstanceId(),
+                                                                   animationActions,
+                                                                   false, WXDomHandler.DELAY_TIME);
     }
-  }
-
-  public static void startAnimation(WXSDKInstance instance, WXComponent component,
-                                    @NonNull WXAnimationBean animationBean, @Nullable String callback) {
-    if(component == null){
-      return;
-    }
-    if (component.getHostView() == null) {
-      AnimationHolder holder = new AnimationHolder(animationBean, callback);
-      component.postAnimation(holder);
-      return;
-    }
-    try {
-      Animator animator = createAnimator(animationBean, component.getHostView(),instance.getInstanceViewPortWidth());
-      if (animator != null) {
-        Animator.AnimatorListener animatorCallback = createAnimatorListener(instance, callback);
-        if(Build.VERSION.SDK_INT<Build.VERSION_CODES.JELLY_BEAN_MR2) {
-          component.getHostView().setLayerType(View.LAYER_TYPE_HARDWARE, null);
-        }
-        Interpolator interpolator = createTimeInterpolator(animationBean);
-        if (animatorCallback != null) {
-          animator.addListener(animatorCallback);
-        }
-        if (interpolator != null) {
-          animator.setInterpolator(interpolator);
-        }
-        animator.setDuration(animationBean.duration);
-        animator.start();
-      }
-    } catch (RuntimeException e) {
-      e.printStackTrace();
-      WXLogUtils.e("", e);
-    }
-  }
-
-  private static @Nullable
-  ObjectAnimator createAnimator(@NonNull WXAnimationBean animation, final View target,final int viewPortWidth) {
-    if(target == null){
-      return null;
-    }
-    WXAnimationBean.Style style = animation.styles;
-    if (style != null) {
-      ObjectAnimator animator;
-      List<PropertyValuesHolder> holders =style.getHolders();
-      if (!TextUtils.isEmpty(style.backgroundColor)) {
-        BorderDrawable borderDrawable;
-        if ((borderDrawable=WXViewUtils.getBorderDrawable(target))!=null) {
-          holders.add(PropertyValuesHolder.ofObject(
-              new BackgroundColorProperty(), new ArgbEvaluator(),
-              borderDrawable.getColor(),
-              WXResourceUtils.getColor(style.backgroundColor)));
-        } else if (target.getBackground() instanceof ColorDrawable) {
-          holders.add(PropertyValuesHolder.ofObject(
-              new BackgroundColorProperty(), new ArgbEvaluator(),
-              ((ColorDrawable) target.getBackground()).getColor(),
-              WXResourceUtils.getColor(style.backgroundColor)));
-        }
-      }
-      if (style.getPivot() != null) {
-        Pair<Float, Float> pair = style.getPivot();
-        target.setPivotX(pair.first);
-        target.setPivotY(pair.second);
-      }
-      animator = ObjectAnimator.ofPropertyValuesHolder(
-          target, holders.toArray(new PropertyValuesHolder[holders.size()]));
-      animator.setStartDelay(animation.delay);
-      if (target.getLayoutParams() != null &&
-          (!TextUtils.isEmpty(style.width) || !TextUtils.isEmpty(style.height))) {
-        DimensionUpdateListener listener = new DimensionUpdateListener(target);
-        ViewGroup.LayoutParams layoutParams = target.getLayoutParams();
-        if (!TextUtils.isEmpty(style.width)) {
-          listener.setWidth(layoutParams.width,
-                            (int) WXViewUtils.getRealPxByWidth(WXUtils.getFloat(style.width),viewPortWidth));
-        }
-        if (!TextUtils.isEmpty(style.height)) {
-          listener.setHeight(layoutParams.height,
-                             (int) WXViewUtils.getRealPxByWidth(WXUtils.getFloat(style.height),viewPortWidth));
-        }
-        animator.addUpdateListener(listener);
-      }
-      return animator;
-    } else {
-      return null;
-    }
-  }
-
-  public static
-  @Nullable
-  Animator.AnimatorListener createAnimatorListener(final WXSDKInstance instance, @Nullable final String callBack) {
-    if (!TextUtils.isEmpty(callBack)) {
-      return new AnimatorListenerAdapter() {
-        @Override
-        public void onAnimationEnd(Animator animation) {
-          if (instance == null) {
-            WXLogUtils.e("RenderActionContextImpl-onAnimationEnd WXSDKInstance == null NPE");
-          } else {
-            WXSDKManager.getInstance().callback(instance.getInstanceId(),
-                                                callBack,
-                                                new HashMap<String, Object>());
-          }
-        }
-      };
-    } else {
-      return null;
-    }
-  }
-
-  private static @Nullable
-  Interpolator createTimeInterpolator(@NonNull WXAnimationBean animation) {
-    String interpolator = animation.timingFunction;
-    if (!TextUtils.isEmpty(interpolator)) {
-      switch (interpolator) {
-        case WXAnimationBean.EASE_IN:
-          return new AccelerateInterpolator();
-        case WXAnimationBean.EASE_OUT:
-          return new DecelerateInterpolator();
-        case WXAnimationBean.EASE_IN_OUT:
-          return new AccelerateDecelerateInterpolator();
-        case WXAnimationBean.LINEAR:
-          return new LinearInterpolator();
-        default:
-          //Parse cubic-bezier
-          try {
-            SingleFunctionParser<Float> parser = new SingleFunctionParser<>(
-                animation.timingFunction,
-                new SingleFunctionParser.FlatMapper<Float>() {
-                  @Override
-                  public Float map(String raw) {
-                    return Float.parseFloat(raw);
-                  }
-                });
-            List<Float> params = parser.parse(WXAnimationBean.CUBIC_BEZIER);
-            if (params != null && params.size() == WXAnimationBean.NUM_CUBIC_PARAM) {
-              return PathInterpolatorCompat.create(
-                  params.get(0), params.get(1), params.get(2), params.get(3));
-            }
-            else {
-              return null;
-            }
-          }catch (RuntimeException e){
-            return null;
-          }
-      }
-    }
-    return null;
   }
 
   //add by moxun on 12/26/2016
   public static class AnimationHolder {
+
     private WXAnimationBean wxAnimationBean;
     private String callback;
 
     public void execute(WXSDKInstance mInstance, WXComponent component) {
-      WXAnimationModule.startAnimation(mInstance, component, wxAnimationBean, callback);
+      RenderAction action = Actions.getAnimationAction(component.getRef(), wxAnimationBean, callback);
+      WXSDKManager.getInstance().getWXRenderManager().runOnThread(mInstance.getInstanceId(), action);
     }
 
-    private AnimationHolder(WXAnimationBean wxAnimationBean, String callback) {
+    public AnimationHolder(WXAnimationBean wxAnimationBean, String callback) {
       this.wxAnimationBean = wxAnimationBean;
       this.callback = callback;
     }

--- a/android/sdk/src/test/java/com/taobao/weex/dom/WXDomStatementTest.java
+++ b/android/sdk/src/test/java/com/taobao/weex/dom/WXDomStatementTest.java
@@ -476,15 +476,4 @@ public class WXDomStatementTest {
     updateFinish();
     stmt.batch();
   }
-
-  @Test
-  public void testStartAnimation() throws Exception {
-    createBody();
-    JSONObject obj;
-    obj = new JSONObject();
-    obj.put("type","div");
-    obj.put("ref","100");
-    addDom(obj,WXDomObject.ROOT,0);
-    stmt.startAnimation("100","",null);
-  }
 }

--- a/android/sdk/src/test/java/com/taobao/weex/ui/animation/WXAnimationModuleTest.java
+++ b/android/sdk/src/test/java/com/taobao/weex/ui/animation/WXAnimationModuleTest.java
@@ -206,8 +206,7 @@ package com.taobao.weex.ui.animation;
 
 import com.taobao.weappplus_sdk.BuildConfig;
 import com.taobao.weex.WXSDKInstanceTest;
-import com.taobao.weex.dom.TestDomObject;
-import com.taobao.weex.ui.component.TestComponent;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -239,21 +238,6 @@ public class WXAnimationModuleTest {
   public void testTransition() throws Exception {
     module.transition("","","");
     module.transition("test","test","");
-  }
-
-  @Test
-  public void testStartAnimation() throws Exception {
-    module.startAnimation(module.mWXSDKInstance,null,null,null);
-
-    TestComponent comp = new TestComponent(module.mWXSDKInstance,new TestDomObject(),null);
-    module.startAnimation(module.mWXSDKInstance,comp,null,null);
-
-    WXAnimationBean animation = new WXAnimationBean();
-    module.startAnimation(module.mWXSDKInstance,comp,animation,null);
-
-    animation.styles = new WXAnimationBean.Style();
-    module.startAnimation(module.mWXSDKInstance,comp,animation,null);
-
   }
 
   @Test


### PR DESCRIPTION
[Android] Refactor animation using Action and perserve `transformOrigin`'s last time state.

Before this commit, transformOrigin is stateless during a sequence of animation, e.g. tranformOrigin would reset to `50%, 50%` every time if it was not given. This commit respect `transformOrigin` last time state unless it is specified this time. Developers who depends on the wrong implementation may run into a problem.

Potential break changes:
* For Android developer: Those who start animation by invoking AnimationModule, RenderManager, or DomManager directly may run into compiling error or runtimeException.
* For Front-end developer: Those who depends on transformOrigin reset to `center center` after each animation will run into problem.