### PR TITLE
* [Android] Add the ability of disable changing layerType

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/WXSDKInstance.java
+++ b/android/sdk/src/main/java/com/taobao/weex/WXSDKInstance.java
@@ -208,6 +208,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.graphics.Color;
+import android.graphics.Paint;
 import android.net.Uri;
 import android.os.Message;
 import android.support.annotation.Nullable;
@@ -293,6 +294,7 @@ public class WXSDKInstance implements IWXActivityStateListener,DomContext, View.
   private boolean isCommit=false;
   private WXGlobalEventReceiver mGlobalEventReceiver=null;
   private boolean trackComponent;
+  private boolean enableLayerType = true;
   private boolean mNeedValidate = false;
   private static volatile int mViewPortWidth = 750;
   private int mInstanceViewPortWidth = 750;
@@ -338,6 +340,29 @@ public class WXSDKInstance implements IWXActivityStateListener,DomContext, View.
 
   public void setTrackComponent(boolean trackComponent) {
     this.trackComponent = trackComponent;
+  }
+
+  /**
+   * Tell whether it is enabled to change the layerType
+   * {@link android.view.View#setLayerType(int, Paint)}
+   * @return True for enable to change the layerType of component, false otherwise. The default
+   * is True
+   */
+  public boolean isLayerTypeEnabled() {
+    return enableLayerType;
+  }
+
+  /**
+   * Enable the ability of changing layerType. e.g. {@link android.view.View#setLayerType(int, Paint)}
+   * Disable the ability of changing layerType will have tremendous <strong>performance
+   * punishment</strong>.
+   *
+   * <strong>Do not</strong> set this to false unless you know exactly what you are doing.
+   * @param enable True for enable to change the layerType of component, false otherwise. The default
+   * is True
+   */
+  public void enableLayerType(boolean enable) {
+    enableLayerType = enable;
   }
 
   public boolean isNeedValidate() {

--- a/android/sdk/src/main/java/com/taobao/weex/dom/action/AnimationAction.java
+++ b/android/sdk/src/main/java/com/taobao/weex/dom/action/AnimationAction.java
@@ -328,7 +328,8 @@ class AnimationAction implements DOMAction, RenderAction {
               .getInstanceViewPortWidth());
           if (animator != null) {
             Animator.AnimatorListener animatorCallback = createAnimatorListener(instance, callback);
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2 && component
+                .enableLayerType() ) {
               component.getHostView().setLayerType(View.LAYER_TYPE_HARDWARE, null);
             }
             Interpolator interpolator = createTimeInterpolator();

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
@@ -159,7 +159,6 @@ import com.taobao.weex.common.IWXObject;
 import com.taobao.weex.common.WXRuntimeException;
 import com.taobao.weex.dom.ImmutableDomObject;
 import com.taobao.weex.dom.WXDomHandler;
-import com.taobao.weex.dom.WXDomManager;
 import com.taobao.weex.dom.WXDomObject;
 import com.taobao.weex.dom.WXDomTask;
 import com.taobao.weex.dom.WXStyle;
@@ -1132,7 +1131,7 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
   }
 
   public void setOpacity(float opacity) {
-    if (opacity >= 0 && opacity <= 1 && mHost.getAlpha() != opacity) {
+    if (opacity >= 0 && opacity <= 1 && mHost.getAlpha() != opacity && enableLayerType()) {
       mHost.setLayerType(View.LAYER_TYPE_HARDWARE, null);
       mHost.setAlpha(opacity);
     }
@@ -1320,7 +1319,7 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
     if (WXEnvironment.isApkDebugable() && !WXUtils.isUiThread()) {
       throw new WXRuntimeException("[WXComponent] destroy can only be called in main thread");
     }
-    if(mHost!= null && mHost.getLayerType()==View.LAYER_TYPE_HARDWARE) {
+    if(mHost!= null && mHost.getLayerType()==View.LAYER_TYPE_HARDWARE && enableLayerType()) {
       mHost.setLayerType(View.LAYER_TYPE_NONE, null);
     }
     removeAllEvent();
@@ -1505,5 +1504,13 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
    */
   public void setStickyOffset(int stickyOffset) {
     mStickyOffset = stickyOffset;
+  }
+
+  /**
+   * For now, this method respect the result of {@link WXSDKInstance#isLayerTypeEnabled()}
+   * @return Refer {@link WXSDKInstance#isLayerTypeEnabled()}
+   */
+  public boolean enableLayerType() {
+    return getInstance().isLayerTypeEnabled();
   }
 }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
@@ -1510,7 +1510,7 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
    * For now, this method respect the result of {@link WXSDKInstance#isLayerTypeEnabled()}
    * @return Refer {@link WXSDKInstance#isLayerTypeEnabled()}
    */
-  public boolean enableLayerType() {
+  public boolean isLayerTypeEnabled() {
     return getInstance().isLayerTypeEnabled();
   }
 }


### PR DESCRIPTION
For certain custom weex instance, one can disable the ability of changing layerType by call `WXSDKInstance.enableLayerType(boolean)`. The default value for this flag is true and setting this to false will have performance punishment。