### PR TITLE
* [ios] fix embed components frame when resizing root view frame

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXEmbedComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXEmbedComponent.m
@@ -186,6 +186,12 @@
     }
 }
 
+- (void)_frameDidCalculated:(BOOL)isChanged
+{
+    [super _frameDidCalculated:isChanged];
+    self.embedInstance.frame = self.calculatedFrame;
+}
+
 - (void)onclickErrorView
 {
     if (self.errorView) {


### PR DESCRIPTION
embed component frame isn’t changed when resizing root view frame