### PR TITLE
* [ios] fix loading indicator animation

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXLoadingIndicator.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXLoadingIndicator.m
@@ -12,6 +12,7 @@
 @implementation WXLoadingIndicator {
     UIActivityIndicatorView *_indicator;
     UIColor *_indicatorColor;
+    BOOL _isAnimating;
 }
 
 - (instancetype)initWithRef:(NSString *)ref type:(NSString *)type styles:(NSDictionary *)styles attributes:(NSDictionary *)attributes events:(NSArray *)events weexInstance:(WXSDKInstance *)weexInstance {
@@ -34,6 +35,9 @@
     if (_indicatorColor) {
         _indicator.color = _indicatorColor;
     }
+    if (_isAnimating) {
+        [_indicator startAnimating];
+    }
 }
 
 - (void)updateStyles:(NSDictionary *)styles {
@@ -53,12 +57,14 @@
 }
 
 - (void)start {
+    _isAnimating = YES;
     if (_indicator) {
         [_indicator startAnimating];
     }
 }
 
 - (void)stop {
+    _isAnimating = NO;
     if (_indicator) {
         [_indicator stopAnimating];
     }


### PR DESCRIPTION
fix loading indicator animation while refresh & loading component display state turn to ‘show’ before indicator is created.

demo for this error:

```vue
<template>
  <list class="wrapper">
      <refresh :display="showRefresh" class="refresh">
        <text v-if="(showRefresh == 'hide')">下拉刷新</text>
        <loading-indicator class="indicator" v-if="(showRefresh == 'show')"></loading-indicator>
      </refresh>
  </list>
</template>

<style>
  .wrapper { margin-top: 120px; }
  .refresh{
    width: 750px; 
    height: 80px; 
    align-items: center;
    background-color: #EFEAE8;
    justify-content: center;
  }

  .indicator{
    width: 60px;
    height: 60px; 
    color:#93D815;
  }
</style>

<script>  
  export default {
    data: function() {
      return {
      showRefresh: 'hide',
    };
    },
    mounted: function() {
      setTimeout(()=>this.showRefresh = 'show', 1000);
    },
  };
</script>
```