### PR TITLE
*[Doc]remove weexpack and devtool link

### DIFF
--- a/doc/_config.yml
+++ b/doc/_config.yml
@@ -322,3 +322,5 @@ alias:
   cn/doc/references/events/blur.html: cn/references/index.html
   cn/doc/references/events/input.html: cn/references/index.html
   cn/doc/references/events/focus.html: cn/references/index.html
+  cn/guide/tools/devtools.html: cn/guide/tools/toolkit.html
+  cn/guide/tools/weexpack.html: cn/guide/tools/toolkit.html

--- a/doc/_config.yml
+++ b/doc/_config.yml
@@ -324,3 +324,5 @@ alias:
   cn/doc/references/events/focus.html: cn/references/index.html
   cn/guide/tools/devtools.html: cn/guide/tools/toolkit.html
   cn/guide/tools/weexpack.html: cn/guide/tools/toolkit.html
+  guide/tools/devtools.html: guide/tools/toolkit.html
+  guide/tools/weexpack.html: guide/tools/toolkit.html

--- a/doc/themes/weex/layout/_partial/header.ejs
+++ b/doc/themes/weex/layout/_partial/header.ejs
@@ -15,10 +15,7 @@
                 <a href="<%= url_for_lang('playground.html') %>">Playground</a>
               </li>
               <li>
-                <a href="<%= url_for_lang('guide/tools/devtools.html') %>">Devtools</a>
-              </li>
-              <li>
-                <a href="<%= url_for_lang('guide/tools/weexpack.html') %>">Weexpack</a>
+                <a href="<%= url_for_lang('guide/tools/toolkit.html') %>">Weex-toolkit</a>
               </li>
               <li>
                 <a href="http://dotwe.org" target="_blank">Code Snippets</a>


### PR DESCRIPTION
We have hidden the two tools for developers. These links will be replace  with the url of`weex-toolkit`.
