### PR TITLE
add a member in WXComponent to flag the component have no view

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
@@ -230,6 +230,10 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
   private PesudoStatus mPesudoStatus = new PesudoStatus();
   private boolean mIsDestroyed = false;
   private boolean mIsDisabled = false;
+  private int mType = TYPE_COMMON;
+
+  public static final int TYPE_COMMON = 0;
+  public static final int TYPE_VIRTUAL = 1;
 
   //Holding the animation bean when component is uninitialized
   public void postAnimation(WXAnimationModule.AnimationHolder holder) {
@@ -318,9 +322,14 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
   }
 
   public WXComponent(WXSDKInstance instance, WXDomObject dom, WXVContainer parent) {
+    this(instance, dom, parent, TYPE_COMMON);
+  }
+
+  public WXComponent(WXSDKInstance instance, WXDomObject dom, WXVContainer parent, int type) {
     mInstance = instance;
     mContext = mInstance.getContext();
     mParent = parent;
+    mType = type;
     mDomObj = dom.clone();
     mCurrentRef = mDomObj.getRef();
     mGestureType = new HashSet<>();
@@ -635,7 +644,7 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
 
   @Deprecated
   public void updateProperties(Map<String, Object> props) {
-    if (props == null || mHost == null) {
+    if (props == null || (mHost == null && !isVirtualComponent())) {
       return;
     }
 
@@ -966,7 +975,7 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
   protected void createViewImpl() {
     if (mContext != null) {
       mHost = initComponentHostView(mContext);
-      if (mHost == null) {
+      if (mHost == null && !isVirtualComponent()) {
         //compatible
         initView();
       }
@@ -1431,9 +1440,13 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
    * @return false component add subview
    */
   public boolean isVirtualComponent(){
-    return false;
+    return mType == TYPE_VIRTUAL;
   }
   public void removeVirtualComponent() {
+  }
+
+  public void setType(int type) {
+    mType = type;
   }
 
   public boolean hasScrollParent(WXComponent component) {


### PR DESCRIPTION
commonly component always has a host view, but some times maybe not,
such as a svg label, the sub component like defs will not have a
hostview, infact, the ellipse has no view too, it just tell us need to
draw a ellipse to it's parent compoent's hostview.

example:

<svg width="100%" height="100%" version="1.1"
xmlns="http://www.w3.org/2000/svg">

<defs>
<linearGradient id="orange_red" x1="0%" y1="0%" x2="100%" y2="0%">
<stop offset="0%" style="stop-color:rgb(255,255,0);
stop-opacity:1"/>
<stop offset="100%" style="stop-color:rgb(255,0,0);
stop-opacity:1"/>
</linearGradient>
</defs>

<ellipse cx="200" cy="190" rx="85" ry="55"
style="fill:url(#orange_red)"/>

</svg>

<!--

Notes: Weex will move into Apache Software Foundation (ASF) on Feb 24 2017.

Our new GitHub repo is https://github.com/apache/incubator-weex

After Feb 24 2017, we only accept pull requests from https://github.com/apache/incubator-weex

Thank you for your support.

----

注意：Weex 将于 2017-02-24 迁移至 Apache 基金会

届时我们会使用新的 GitHub 仓库：https://github.com/apache/incubator-weex 并在那里继续接受大家的 pull request。

更多详情请关注：https://github.com/weexteam/article/issues/130

感谢理解和支持

-->

<!--

It's ***RECOMMENDED*** to submit typo fix, new demo and tiny bugfix to `dev` branch. New feature and other modifications can be submitted to "domain" branch including `ios`, `android`, `jsfm`, `html5`.
    
See [Branch Strategy](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management) for more detail.

----

（请在***提交***前删除这段描述）

错别字修改、新 demo、较小的 bugfix 都可以直接提到 `dev` 分支；新需求以及任何你不确定影响面的改动，请提交到对应“领域”的分支（`ios`、`android`、`jsfm`、`html5`）。

查看完整的[分支策略 (英文)](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management)。

-->
