### PR TITLE
* [html5] scrollToElement method support no animation

### DIFF
--- a/html5/render/vue/modules/dom.js
+++ b/html5/render/vue/modules/dom.js
@@ -85,6 +85,10 @@ export default {
           + 'otherwise it may not works well on native.')
       }
 
+      if (options && options.animated === false) {
+        return scrollElement.call(scroller.$el, dSuffix, offset)
+      }
+
       step({
         scrollable: scroller.$el,
         startTime: now(),

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "weex-styler": "0.1.9"
   },
   "devDependencies": {
+    "autoprefixer": "^6.7.7",
     "babel-core": "^6.17.0",
     "babel-eslint": "^7.2.1",
     "babel-istanbul": "^0.11.0",


### PR DESCRIPTION
scrollToElement method support no animation.

weex.requireModule('dom').scrollToElement(el, {animated: false})