### PR TITLE
+ [ios] add feature timer

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Bridge/WXBridgeContext.m
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXBridgeContext.m
@@ -246,6 +246,10 @@ _Pragma("clang diagnostic pop") \
     if([self.insStack containsObject:instance]){
         [self.insStack removeObject:instance];
     }
+    
+    if(_jsBridge){
+        [_jsBridge removeTimers:instance];
+    }
 
     if(self.sendQueue[instance]){
         [self.sendQueue removeObjectForKey:instance];

--- a/ios/sdk/WeexSDK/Sources/Protocol/WXBridgeProtocol.h
+++ b/ios/sdk/WeexSDK/Sources/Protocol/WXBridgeProtocol.h
@@ -44,6 +44,11 @@ typedef void (^WXJSCallNativeComponent)(NSString *instanceId, NSString *componen
  */
 - (void)resetEnvironment;
 
+/**
+ * Remove instance's timer.
+ */
+-(void)removeTimers:(NSString *)instance;
+
 @optional
 
 /**


### PR DESCRIPTION
support jsfm call timer directly , not through bridge.
Because wxtimermodule execute until the jsbridge thread finish.  it will delay .
the minimum time interval  is 14ms average  and is not precarious in the old method
the minimum time interval  is 3ms average and is Stable in new method

Android PR:https://github.com/apache/incubator-weex/pull/221
