### PR TITLE
+ [ios] picker support custom title title color background color and etc

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
@@ -295,7 +295,7 @@ WX_EXPORT_METHOD(@selector(pickTime:callback:))
     self.index = row;
     if(self.selectionColor) {
         UILabel *labelSelected = (UILabel*)[pickerView viewForRow:row forComponent:component];
-        [labelSelected setBackgroundColor:self.selectionColor?self.selectionColor:[UIColor whiteColor]];
+        [labelSelected setBackgroundColor:self.selectionColor];
     }
 }
 

--- a/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
@@ -31,7 +31,7 @@
 @property(nonatomic,strong)UIColor *cancelTitleColor;
 @property(nonatomic,strong)UIColor *confirmTitleColor;
 @property(nonatomic,strong)UIColor *titleBackgroundColor;
-@property(nonatomic)NSInteger height;
+@property(nonatomic)CGFloat height;
 @property(nonatomic,strong)UIColor *textColor;
 @property(nonatomic,strong)UIColor *selectionColor;
 //data

--- a/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
@@ -23,6 +23,17 @@
 @property(nonatomic,strong)UIView *backgroundView;
 @property(nonatomic,strong)UIView *pickerView;
 
+//custom
+@property(nonatomic,copy)NSString *title;
+@property(nonatomic,strong)UIColor *titleColor;
+@property(nonatomic,copy)NSString *cancelTitle;
+@property(nonatomic,copy)NSString *confirmTitle;
+@property(nonatomic,strong)UIColor *cancelTitleColor;
+@property(nonatomic,strong)UIColor *confirmTitleColor;
+@property(nonatomic,strong)UIColor *titleBackgroundColor;
+@property(nonatomic)NSInteger height;
+@property(nonatomic,strong)UIColor *textColor;
+@property(nonatomic,strong)UIColor *selectionColor;
 //data
 @property(nonatomic,copy)NSArray *items;
 @property(nonatomic)BOOL isAnimating;
@@ -53,6 +64,36 @@ WX_EXPORT_METHOD(@selector(pickTime:callback:))
     }
     if (options[@"index"]) {
         index = [WXConvert NSInteger:options[@"index"]];
+    }
+    if (options[@"title"]) {
+        self.title = [WXConvert NSString:options[@"title"]];
+    }
+    if (options[@"titleColor"]) {
+        self.titleColor = [WXConvert UIColor:options[@"titleColor"]];
+    }
+    if (options[@"cancelTitle"]) {
+        self.cancelTitle = [WXConvert NSString:options[@"cancelTitle"]];
+    }
+    if (options[@"confirmTitle"]) {
+        self.confirmTitle = [WXConvert NSString:options[@"confirmTitle"]];
+    }
+    if (options[@"cancelTitleColor"]) {
+        self.cancelTitleColor = [WXConvert UIColor:options[@"cancelTitleColor"]];
+    }
+    if (options[@"confirmTitleColor"]) {
+        self.confirmTitleColor = [WXConvert UIColor:options[@"confirmTitleColor"]];
+    }
+    if (options[@"titleBackgroundColor"]) {
+        self.titleBackgroundColor = [WXConvert UIColor:options[@"titleBackgroundColor"]];
+    }
+    if (options[@"textColor"]) {
+        self.textColor = [WXConvert UIColor:options[@"textColor"]];
+    }
+    if (options[@"selectionColor"]) {
+        self.selectionColor = [WXConvert UIColor:options[@"selectionColor"]];
+    }
+    if (options[@"height"]) {
+        self.height = [WXConvert CGFloat:options[@"height"]];
     }
     if (items && [items count]>0 && [self isRightItems:items]) {
         [self createPicker:items index:index];
@@ -160,17 +201,52 @@ WX_EXPORT_METHOD(@selector(pickTime:callback:))
     [self.backgroundView addGestureRecognizer:tapGesture];
     self.pickerView = [self createPickerView];
     UIToolbar *toolBar=[[UIToolbar alloc]initWithFrame:CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, WXPickerToolBarHeight)];
-    [toolBar setBackgroundColor:[UIColor whiteColor]];
+    toolBar.barTintColor = self.titleBackgroundColor?self.titleBackgroundColor:[UIColor whiteColor];
+    
+    
+    
     UIBarButtonItem* noSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
     noSpace.width=10;
-    UIBarButtonItem* doneBtn = [[UIBarButtonItem alloc]initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(done:)];
-    UIBarButtonItem *flexSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
-    UIBarButtonItem* cancelBtn = [[UIBarButtonItem alloc]initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancel:)];
+    
+    UIBarButtonItem* doneBtn ;
+    if (self.confirmTitle.length >0) {
+        doneBtn = [[UIBarButtonItem alloc] initWithTitle:self.confirmTitle style:UIBarButtonItemStyleBordered target:self action:@selector(done:)];
+    }else {
+       doneBtn = [[UIBarButtonItem alloc]initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(done:)];
+    }
+    if(self.confirmTitleColor){
+        doneBtn.tintColor = self.confirmTitleColor;
+    }
+    UIBarButtonItem *cancelBtn;
+    if (self.cancelTitle.length >0) {
+        cancelBtn = [[UIBarButtonItem alloc] initWithTitle:self.cancelTitle style:UIBarButtonItemStyleBordered target:self action:@selector(cancel:)];
+    }else {
+        cancelBtn = [[UIBarButtonItem alloc]initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancel:)];
+    }
+    if(self.cancelTitleColor){
+        cancelBtn.tintColor = self.cancelTitleColor;
+    }
+    UIBarButtonItem* flexSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
     [toolBar setItems:[NSArray arrayWithObjects:noSpace,cancelBtn,flexSpace,doneBtn,noSpace, nil]];
+    UILabel *titleLabel = [UILabel new];
+    titleLabel.frame = CGRectMake(0, 0, 200, WXPickerToolBarHeight);
+    titleLabel.center = toolBar.center;
+    titleLabel.textAlignment = NSTextAlignmentCenter;
+    if(self.titleColor){
+        titleLabel.textColor = self.textColor;
+    }
+    if(self.title.length>0){
+        titleLabel.text = self.title;
+        [toolBar addSubview:titleLabel];
+    }
     [self.pickerView addSubview:toolBar];
     self.picker = [[UIPickerView alloc]init];
     self.picker.delegate = self;
-    CGRect pickerFrame = CGRectMake(0, WXPickerToolBarHeight, [UIScreen mainScreen].bounds.size.width, WXPickerHeight-WXPickerToolBarHeight);
+    CGFloat height = WXPickerHeight;
+    if (WXFloatEqual(self.height, 0)){
+        height = self.height>WXPickerToolBarHeight?self.height:WXPickerHeight;
+    }
+    CGRect pickerFrame = CGRectMake(0, WXPickerToolBarHeight, [UIScreen mainScreen].bounds.size.width, height-WXPickerToolBarHeight);
     self.picker.backgroundColor = [UIColor whiteColor];
     self.picker.frame = pickerFrame;
     [self.pickerView addSubview:self.picker];
@@ -180,7 +256,11 @@ WX_EXPORT_METHOD(@selector(pickTime:callback:))
 -(UIView *)createPickerView
 {
     UIView *view = [UIView new];
-    view.frame = CGRectMake(0, [UIScreen mainScreen].bounds.size.height, [UIScreen mainScreen].bounds.size.width, WXPickerHeight);
+    CGFloat height = WXPickerHeight;
+    if (WXFloatEqual(self.height, 0)){
+        height = self.height>WXPickerToolBarHeight?self.height:WXPickerHeight;
+    }
+    view.frame = CGRectMake(0, [UIScreen mainScreen].bounds.size.height, [UIScreen mainScreen].bounds.size.width, height);
     view.backgroundColor = [UIColor whiteColor];
     return view;
 }
@@ -213,7 +293,37 @@ WX_EXPORT_METHOD(@selector(pickTime:callback:))
 - (void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component
 {
     self.index = row;
+    if(self.selectionColor) {
+        UILabel *labelSelected = (UILabel*)[pickerView viewForRow:row forComponent:component];
+        [labelSelected setBackgroundColor:self.selectionColor?self.selectionColor:[UIColor whiteColor]];
+    }
 }
+
+- (NSAttributedString *)pickerView:(UIPickerView *)pickerView attributedTitleForRow:(NSInteger)row forComponent:(NSInteger)component{
+    NSString * reStr = self.items[row];
+    NSMutableAttributedString * attriStr = [[NSMutableAttributedString alloc] initWithString:reStr];
+    UIColor *color = self.textColor?self.textColor:[UIColor blackColor];
+    [attriStr addAttribute:NSForegroundColorAttributeName value:color range:NSMakeRange(0, reStr.length)];
+
+    return attriStr;
+}
+
+-(UIView *)pickerView:(UIPickerView *)pickerView viewForRow:(NSInteger)row forComponent:(NSInteger)component reusingView:(UIView *)view
+{
+    
+    UILabel *label = (id)view;
+    
+    if (!label)
+    {
+        
+        label= [[UILabel alloc] initWithFrame:CGRectMake(0.0f, 0.0f, [pickerView rowSizeForComponent:component].width, [pickerView rowSizeForComponent:component].height)];
+        label.textAlignment = NSTextAlignmentCenter;
+        label.text = self.items[row];
+    }
+    
+    return label;
+}
+
 
 #pragma mark -
 #pragma Date & Time Picker


### PR DESCRIPTION
+ [ios] picker support custom 

title
titleColor
cancelTitle
confirmTitle
cancelTitleColor
confirmTitleColor
titleBackgroundColor
height
textColor
selectionColor

demo

```
<template>
  <scroller>
    <wxc-panel title="picker module" type="primary">
      <text style="margin-bottom: 20px;">pick value: {{value}}</text>
      <wxc-button type="primary" onclick="{{pick}}" value="single pick" style="margin-bottom: 20px;"></wxc-button>
      <wxc-button type="primary" onclick="{{pickDate}}" value="pickDate" style="margin-bottom: 20px;"></wxc-button>
      <wxc-button type="primary" onclick="{{pickTime}}" value="pickTime"></wxc-button>
    </wxc-panel>

    <wxc-panel title="input component" type="primary">
      <text>onchange: {{txtChange}}</text>
      <input
              type="date"
              placeholder="select date"
              class="input"
              autofocus="false"
              value=""
              onchange="onchange"
              max = "2029-11-28"
              min = "2015-11-28"
      />
      <input
              type="time"
              placeholder="select time"
              class="input"
              autofocus="false"
              value=""
              onchange="onchange"
      />
    </wxc-panel>
  </scroller>
</template>

<style>
  .input {
    font-size: 60px;
    height: 80px;
    width: 400px;
  }
</style>

<script>
  require('weex-components');
  module.exports = {
    data: {
      value: '',
      index: 0,
      txtChange: ''
    },
    methods: {
      pick: function() {
        var picker = require('@weex-module/picker');
        var items = new Array("Saab","Volvo","BMW");
        var self = this;
        picker.pick({
          'items':items,
          'index':self.index,
          'title':'test',
          'titleColor':'blue',
          'cancelTitle':'cccc',
          'confirmTitle':'dddd',
          'cancelTitleColor':'black',
          'confirmTitleColor':'yellow',
          'titleBackgroundColor':'green',
          'height':600,
          'textColor':'red',
          'selectionColor':'gray'
        },function (ret) {
          var result = ret.result;
          if(result == 'success')
          {
            self.value = items[ret.data];
            self.index = ret.data;
          }
        });

      },
      pickDate: function() {
        var picker = require('@weex-module/picker');
        var self = this;
        picker.pickDate({
          'value':'2016-11-28',
          'max':'2029-11-28',
          'min':'2015-11-28'
        },function (ret) {
          var result = ret.result;
          if(result == 'success')
          {
            self.value = ret.data;
          }
        });
      },
      pickTime: function() {
        var picker = require('@weex-module/picker');
        var self = this;
        picker.pickTime({
          'value':'19:24'
        },function (ret) {
          var result = ret.result;
          if(result == 'success')
          {
            self.value = ret.data;
          }
        });
      },
      onchange: function(event) {
        this.txtChange = event.value;
        console.log('onchange', event.value);
      }
    }
  }
</script>

```