### PR TITLE
修复iOS SDK添加系统返回手势的bug

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Controller/WXBaseViewController.h
+++ b/ios/sdk/WeexSDK/Sources/Controller/WXBaseViewController.h
@@ -15,7 +15,7 @@
  * special bundle URL.
  */
 
-@interface WXBaseViewController : UIViewController <UIGestureRecognizerDelegate>
+@interface WXBaseViewController : UIViewController
 
 /**
  * @abstract initializes the viewcontroller with bundle url.

--- a/ios/sdk/WeexSDK/Sources/Controller/WXBaseViewController.m
+++ b/ios/sdk/WeexSDK/Sources/Controller/WXBaseViewController.m
@@ -66,7 +66,6 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    [self addEdgePop];
     self.view.backgroundColor = [UIColor whiteColor];
     self.automaticallyAdjustsScrollViewInsets = NO;
     [self _renderWithURL:_sourceURL];
@@ -104,21 +103,6 @@
 - (void)refreshWeex
 {
     [self _renderWithURL:_sourceURL];
-}
-
-- (void)addEdgePop
-{
-    self.navigationController.interactivePopGestureRecognizer.delegate = self;
-}
-
-#pragma mark- UIGestureRecognizerDelegate
-
-- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
-{
-    if (!self.navigationController || [self.navigationController.viewControllers count] == 1) {
-        return NO;
-    }
-    return YES;
 }
 
 - (void)_renderWithURL:(NSURL *)sourceURL

--- a/ios/sdk/WeexSDK/Sources/Controller/WXRootViewController.m
+++ b/ios/sdk/WeexSDK/Sources/Controller/WXRootViewController.m
@@ -12,7 +12,7 @@
 
 typedef void(^OperationBlock)(void);
 
-@interface WXRootViewController()
+@interface WXRootViewController() <UIGestureRecognizerDelegate>
 
 @property(nonatomic, strong) WXThreadSafeMutableArray *operationArray;
 @property (nonatomic, assign) BOOL operationInProcess;
@@ -20,6 +20,11 @@ typedef void(^OperationBlock)(void);
 @end
 
 @implementation WXRootViewController
+
+- (void)viewDidLoad
+{
+    self.interactivePopGestureRecognizer.delegate = self;
+}
 
 - (id)initWithSourceURL:(NSURL *)sourceURL
 {
@@ -101,6 +106,16 @@ typedef void(^OperationBlock)(void);
         _operationInProcess = YES;
         operation();
     }
+}
+
+#pragma mark- UIGestureRecognizerDelegate
+
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
+{
+    if ([self.viewControllers count] == 1) {
+        return NO;
+    }
+    return YES;
 }
 
 - (NSMutableArray *)pendingBlocks


### PR DESCRIPTION
这是一个早期修改右滑手势返回留下的bug，我在源仓库中提过一个[pr](https://github.com/alibaba/weex/pull/2667),但是并没有被合并到主仓库中，目前发现这bug依然存在。希望能够解决一下。


### 之前的描述如下
-----
### 描述
在[#2433](https://github.com/alibaba/weex/pull/2433)中，我将sdk中添加用来右滑返回的手势，更换成系统提供的方式，但是在最近的开发中，发现这种添加方式存在以下问题：
  在WXBaseViewController中设置navigationController.interactivePopGestureRecognizer.delegate，每次创建baseVC对象时，那么delegate都会指向这个新的baseVC，导致了navigator的手势效果始终都只有栈顶的baseVC有； 这样当栈顶的baseVC弹出后，navigationController.interactivePopGestureRecognizer.delegate=nil,导致了后面的baseVC都不能够使用手势返回； 

### 解决方案
为了保证interactivePopGestureRecognizer的代理始终存在，将其设置在WXRootViewController的viewDidLoad()中，保证这个手势的delegate始终都不会为nil，这样也降低了WXBaseVC每次都去增加手势的任务
### 提醒
如果是在项目中集成weex页面的，也只需在本地项目中的navigationController的viewDidLoad()中，设置interactivePopGestureRecognizer代理即可
  