### PR TITLE
0.12 dev old slider remove start end events

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXSliderComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXSliderComponent.m
@@ -296,6 +296,15 @@
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
+    [NSObject cancelPreviousPerformRequestsWithTarget:self];
+    __weak typeof(self) weakSelf = self;
+    if (!weakSelf)
+    {
+        return;
+    }
+    //ensure that the end of scroll is fired.
+    [self performSelector:@selector(scrollViewDidEndScrollingAnimation:) withObject:nil afterDelay:0.3];
+    
     UIView *itemView = nil;
     for (itemView in self.itemViews) {
         if ([self _isItemViewVisiable:itemView]) {
@@ -308,9 +317,6 @@
     if (self.delegate && [self.delegate respondsToSelector:@selector(sliderView:sliderViewDidScroll:)]) {
         [self.delegate sliderView:self sliderViewDidScroll:self.scrollView];
     }
-    //[NSObject cancelPreviousPerformRequestsWithTarget:self];
-    //ensure that the end of scroll is fired.
-    //[self performSelector:@selector(scrollViewDidEndScrollingAnimation:) withObject:nil afterDelay:0.3];
 }
 
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
@@ -387,7 +393,7 @@
         }
         
         _scrollable = attributes[@"scrollable"] ? [WXConvert BOOL:attributes[@"scrollable"]] : YES;
-
+        
         if (attributes[@"offsetXAccuracy"]) {
             _offsetXAccuracy = [WXConvert CGFloat:attributes[@"offsetXAccuracy"]];
         }
@@ -489,7 +495,7 @@
     WXSliderView *sliderView = (WXSliderView *)_view;
     [sliderView removeItemView:view];
     [sliderView setCurrentIndex:0];
-}
+}ggg
 
 - (void)updateAttributes:(NSDictionary *)attributes
 {
@@ -509,7 +515,7 @@
         
         if (_autoPlay) {
             [self _startAutoPlayTimer];
-        } 
+        }
     }
     
     if (attributes[@"index"]) {
@@ -594,7 +600,7 @@
 - (void)_autoPlayOnTimer
 {
     WXSliderView *sliderView = (WXSliderView *)self.view;
-
+    
     int indicatorCnt = 0;
     for (int i = 0; i < [self.childrenView count]; ++i) {
         if ([self.childrenView[i] isKindOfClass:[WXIndicatorView class]]) {

--- a/ios/sdk/WeexSDK/Sources/Component/WXSliderComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXSliderComponent.m
@@ -31,8 +31,9 @@
 
 - (void)sliderView:(WXSliderView *)sliderView sliderViewDidScroll:(UIScrollView *)scrollView;
 - (void)sliderView:(WXSliderView *)sliderView didScrollToItemAtIndex:(NSInteger)index;
-- (void)sliderView:(WXSliderView *)sliderView scrollViewDidStartScroll:(UIScrollView *)scrollView;
-- (void)sliderView:(WXSliderView *)sliderView scrollViewDidStopScroll:(UIScrollView *)scrollView;
+
+@optional
+- (void)sliderView:(WXSliderView *)sliderView scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView;
 
 @end
 
@@ -44,7 +45,6 @@
 @property (nonatomic, strong) UIScrollView *scrollView;
 @property (nonatomic, strong) NSMutableArray *itemViews;
 @property (nonatomic, assign) NSInteger currentIndex;
-@property (nonatomic, assign) BOOL isStartScroll;
 
 - (UIScrollView *)scrollView;
 - (void)insertItemView:(UIView *)view atIndex:(NSInteger)index;
@@ -296,15 +296,6 @@
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
-    [NSObject cancelPreviousPerformRequestsWithTarget:self];
-    __weak typeof(self) weakSelf = self;
-    if (!weakSelf)
-    {
-        return;
-    }
-    //ensure that the end of scroll is fired.
-    [self performSelector:@selector(scrollViewDidEndScrollingAnimation:) withObject:nil afterDelay:0.3];
-    
     UIView *itemView = nil;
     for (itemView in self.itemViews) {
         if ([self _isItemViewVisiable:itemView]) {
@@ -336,8 +327,8 @@
 // called when setContentOffset/scrollRectVisible:animated: finishes. called from the performselector in scrollViewDidScroll if not animating.
 -(void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView
 {
-    if (self.delegate && [self.delegate respondsToSelector:@selector(sliderView:scrollViewDidStopScroll:)]) {
-        [self.delegate sliderView:self scrollViewDidStopScroll:scrollView];
+    if (self.delegate && [self.delegate respondsToSelector:@selector(sliderView:scrollViewDidEndScrollingAnimation:)]) {
+        [self.delegate sliderView:self scrollViewDidEndScrollingAnimation:scrollView];
     }
 }
 
@@ -356,9 +347,6 @@
 @property (nonatomic, assign) CGFloat offsetXAccuracy;
 @property (nonatomic, assign) BOOL  sliderChangeEvent;
 @property (nonatomic, assign) BOOL  sliderScrollEvent;
-@property (nonatomic, assign) BOOL  sliderScrollStartEvent;
-@property (nonatomic, assign) BOOL  sliderScrollEndEvent;
-@property (nonatomic, assign) BOOL  sliderStartEventFired;
 @property (nonatomic, strong) NSMutableArray *childrenView;
 @property (nonatomic, assign) BOOL scrollable;
 
@@ -495,7 +483,7 @@
     WXSliderView *sliderView = (WXSliderView *)_view;
     [sliderView removeItemView:view];
     [sliderView setCurrentIndex:0];
-}ggg
+}
 
 - (void)updateAttributes:(NSDictionary *)attributes
 {
@@ -544,12 +532,6 @@
     if ([eventName isEqualToString:@"scroll"]) {
         _sliderScrollEvent = YES;
     }
-    if ([eventName isEqualToString:@"scrollstart"]) {
-        _sliderScrollStartEvent = YES;
-    }
-    if ([eventName isEqualToString:@"scrollend"]) {
-        _sliderScrollEndEvent = YES;
-    }
 }
 
 - (void)removeEvent:(NSString *)eventName
@@ -559,12 +541,6 @@
     }
     if ([eventName isEqualToString:@"scroll"]) {
         _sliderScrollEvent = NO;
-    }
-    if ([eventName isEqualToString:@"scrollstart"]) {
-        _sliderScrollStartEvent = NO;
-    }
-    if ([eventName isEqualToString:@"scrollend"]) {
-        _sliderScrollEndEvent = NO;
     }
 }
 
@@ -630,9 +606,6 @@
             [self fireEvent:@"scroll" params:@{@"offsetXRatio":[NSNumber numberWithFloat:offsetXRatio]} domChanges:nil];
         }
     }
-    if (!_sliderStartEventFired) {
-        [self sliderView:sliderView scrollViewDidStartScroll:scrollView];
-    }
 }
 
 - (void)sliderView:(WXSliderView *)sliderView didScrollToItemAtIndex:(NSInteger)index
@@ -641,22 +614,6 @@
     if (_sliderChangeEvent) {
         [self fireEvent:@"change" params:@{@"index":@(index)} domChanges:@{@"attrs": @{@"index": @(index)}}];
     }
-}
-
-- (void)sliderView:(WXSliderView *)sliderView scrollViewDidStartScroll:(UIScrollView *)scrollView
-{
-    if (_sliderScrollStartEvent) {
-        [self fireEvent:@"scrollstart" params:nil domChanges:nil];
-    }
-    _sliderStartEventFired = YES;
-}
-
-- (void)sliderView:(WXSliderView *)sliderView scrollViewDidStopScroll:(UIScrollView *)scrollView
-{
-    if (_sliderScrollEndEvent) {
-        [self fireEvent:@"scrollend" params:nil domChanges:nil];
-    }
-    _sliderStartEventFired = NO;
 }
 
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView


### PR DESCRIPTION
remove start event and stop event from slider component. and fix the crash in didscroll method on iOS 8.x .

<!--

Notes: Weex will move into Apache Software Foundation (ASF) on Feb 24 2017.

Our new GitHub repo is https://github.com/apache/incubator-weex

After Feb 24 2017, we only accept pull requests from https://github.com/apache/incubator-weex

Thank you for your support.

----

注意：Weex 将于 2017-02-24 迁移至 Apache 基金会

届时我们会使用新的 GitHub 仓库：https://github.com/apache/incubator-weex 并在那里继续接受大家的 pull request。

更多详情请关注：https://github.com/weexteam/article/issues/130

感谢理解和支持

-->

<!--

It's ***RECOMMENDED*** to submit typo fix, new demo and tiny bugfix to `dev` branch. New feature and other modifications can be submitted to "domain" branch including `ios`, `android`, `jsfm`, `html5`.
    
See [Branch Strategy](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management) for more detail.

----

（请在***提交***前删除这段描述）

错别字修改、新 demo、较小的 bugfix 都可以直接提到 `dev` 分支；新需求以及任何你不确定影响面的改动，请提交到对应“领域”的分支（`ios`、`android`、`jsfm`、`html5`）。

查看完整的[分支策略 (英文)](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management)。

-->
