### PR TITLE
* [android] stop load when src is empty

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXEmbed.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXEmbed.java
@@ -236,7 +236,7 @@ public class WXEmbed extends WXDiv implements WXSDKInstance.OnInstanceVisibleLis
       mNestedInstance.destroy();
       mNestedInstance = null;
     }
-    if (mIsVisible) {
+    if (mIsVisible && !TextUtils.isEmpty(this.src)) {
       loadContent();
     }
   }


### PR DESCRIPTION
when one weex page has many embed component with empty src, it will lead to downgrade logic, and will cause performance low, so should stop load when src is empty