### PR TITLE
+ [html5] add jsonpCallback support

### DIFF
--- a/html5/render/browser/extend/api/stream.js
+++ b/html5/render/browser/extend/api/stream.js
@@ -12,7 +12,7 @@ let jsonpCnt = 0
 const ERROR_STATE = -1
 
 function _jsonp (config, callback, progressCallback) {
-  const cbName = 'jsonp_' + (++jsonpCnt)
+  const cbName = config.jsonpCallback || 'jsonp_' + (++jsonpCnt)
   let url
 
   if (!config.url) {


### PR DESCRIPTION
stream 模块支持jsonpcallback自定义，因为有的api会先经过cdn缓存，为了避免jsonpcallback name穿透缓存，所以希望可以添加jsonpcallback的的自定义功能。
