### PR TITLE
解决rewrite协议的一个bug

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Protocol/WXURLRewriteProtocol.h
+++ b/ios/sdk/WeexSDK/Sources/Protocol/WXURLRewriteProtocol.h
@@ -27,7 +27,7 @@ do {\
     (*newUrl) = nil;\
     id<WXURLRewriteProtocol> rewriteHandler = [WXHandlerFactory handlerForProtocol:@protocol(WXURLRewriteProtocol)];\
     if ([rewriteHandler respondsToSelector:@selector(rewriteURL:withResourceType:withInstance:)]) {\
-        (*newUrl) = [[rewriteHandler rewriteURL:url withResourceType:WXResourceTypeLink withInstance:instance].absoluteString mutableCopy];\
+        (*newUrl) = [[rewriteHandler rewriteURL:url withResourceType:resourceType withInstance:instance].absoluteString mutableCopy];\
     }\
 } while(0);
 


### PR DESCRIPTION
fix a bug on WXURLRewriteProtocol.h.
The unfixed code will lead to a bug which cause the implement of WXURLRewriteProtocol would receive a static resource type.