### PR TITLE
+ [android] add needLayout option for animation module

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/dom/action/AnimationAction.java
+++ b/android/sdk/src/main/java/com/taobao/weex/dom/action/AnimationAction.java
@@ -133,6 +133,9 @@ class AnimationAction implements DOMAction, RenderAction {
 
   private void startAnimation(@NonNull WXSDKInstance instance, @Nullable WXComponent component) {
     if (component != null) {
+      if (mAnimationBean != null) {
+        component.setNeedLayoutOnAnimation(mAnimationBean.needLayout);
+      }
       if (component.getHostView() == null) {
         WXAnimationModule.AnimationHolder holder = new WXAnimationModule.AnimationHolder(mAnimationBean, callback);
         component.postAnimation(holder);

--- a/android/sdk/src/main/java/com/taobao/weex/ui/animation/DimensionUpdateListener.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/animation/DimensionUpdateListener.java
@@ -27,6 +27,9 @@ import android.support.v4.util.Pair;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.taobao.weex.ui.component.WXComponent;
+import com.taobao.weex.ui.view.IRenderResult;
+
 public class DimensionUpdateListener implements ValueAnimator.AnimatorUpdateListener {
 
   private View view;
@@ -67,6 +70,15 @@ public class DimensionUpdateListener implements ValueAnimator.AnimatorUpdateList
       }
       if (preHeight != layoutParams.height || preWidth != layoutParams.width) {
         view.requestLayout();
+      }
+
+      if (view instanceof IRenderResult) {
+        WXComponent component = ((IRenderResult) view).getComponent();
+        if (component != null) {
+          if (preWidth != layoutParams.width || preHeight != layoutParams.height) {
+            component.notifyNativeSizeChanged(layoutParams.width, layoutParams.height);
+          }
+        }
       }
     }
   }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/animation/DimensionUpdateListener.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/animation/DimensionUpdateListener.java
@@ -76,6 +76,8 @@ public class DimensionUpdateListener implements ValueAnimator.AnimatorUpdateList
         WXComponent component = ((IRenderResult) view).getComponent();
         if (component != null) {
           if (preWidth != layoutParams.width || preHeight != layoutParams.height) {
+            //Notify the animated component it native size has changed
+            //The component will decides whether to update domobject
             component.notifyNativeSizeChanged(layoutParams.width, layoutParams.height);
           }
         }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/animation/WXAnimationBean.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/animation/WXAnimationBean.java
@@ -54,6 +54,7 @@ public class WXAnimationBean {
   public long duration;
   public String timingFunction;
   public Style styles;
+  public boolean needLayout;
 
   public static class Style {
 

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
@@ -1452,10 +1452,16 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
     return getInstance().isLayerTypeEnabled();
   }
 
+  /**
+   * Sets whether or not to relayout page during animation, default is false
+   */
   public void setNeedLayoutOnAnimation(boolean need) {
     this.mNeedLayoutOnAnimation = need;
   }
 
+  /**
+   * Trigger a updateStyle invoke to relayout current page
+   */
   public void notifyNativeSizeChanged(int w, int h) {
     if (!mNeedLayoutOnAnimation) {
       return;

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
@@ -122,6 +122,7 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
   private boolean mIsDestroyed = false;
   private boolean mIsDisabled = false;
   private int mType = TYPE_COMMON;
+  private boolean mNeedLayoutOnAnimation = false;
 
   public static final int TYPE_COMMON = 0;
   public static final int TYPE_VIRTUAL = 1;
@@ -1449,5 +1450,35 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
    */
   public boolean isLayerTypeEnabled() {
     return getInstance().isLayerTypeEnabled();
+  }
+
+  public void setNeedLayoutOnAnimation(boolean need) {
+    this.mNeedLayoutOnAnimation = need;
+  }
+
+  public void notifyNativeSizeChanged(int w, int h) {
+    if (!mNeedLayoutOnAnimation) {
+      return;
+    }
+
+    Message message = Message.obtain();
+    WXDomTask task = new WXDomTask();
+    task.instanceId = getInstanceId();
+    if (task.args == null) {
+      task.args = new ArrayList<>();
+    }
+
+    JSONObject style = new JSONObject(2);
+    float webW = WXViewUtils.getWebPxByWidth(w);
+    float webH = WXViewUtils.getWebPxByWidth(h);
+
+    style.put("width", webW);
+    style.put("height", webH);
+
+    task.args.add(getRef());
+    task.args.add(style);
+    message.obj = task;
+    message.what = WXDomHandler.MsgType.WX_DOM_UPDATE_STYLE;
+    WXSDKManager.getInstance().getWXDomManager().sendMessage(message);
   }
 }


### PR DESCRIPTION
Fix the [WEEX-28](https://issues.apache.org/jira/browse/WEEX-28)
add support of all views' layout when animating.
Use `needLayout` argument to open this feature.

testcase:http://dotwe.org/weex/77b71bd7a331f141521bea05a86c2ad0