### PR TITLE
* [android] fixed issues #35. when a tag href is empty

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXA.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXA.java
@@ -50,7 +50,7 @@ public class WXA extends WXDiv {
         ImmutableDomObject domObject = getDomObject();
         if (domObject != null) {
           WXAttr attr = domObject.getAttrs();
-          if (attr !=null && (href = (String)attr.get("href")) != null) {
+          if (attr != null && (href = (String)attr.get("href")) != null && !TextUtils.isEmpty(href)) {
             ATagUtil.onClick(null, getInstanceId(), href);
           }
         } else {


### PR DESCRIPTION
As https://issues.apache.org/jira/browse/WEEX-35 ，Let iOS and Android A component open empty url the same logic