### PR TITLE
* [android] Fix mixing background-color and border-color(rgba)

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/border/BorderDrawable.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/border/BorderDrawable.java
@@ -104,6 +104,8 @@ public class BorderDrawable extends Drawable {
   public void draw(@NonNull Canvas canvas) {
     canvas.save();
     updateBorderOutline();
+    //Shader uses alpha as well.
+    mPaint.setAlpha(255);
     if (mPathForBorderOutline != null) {
       int useColor = WXViewUtils.multiplyColorAlpha(mColor, mAlpha);
       if (mShader != null) {


### PR DESCRIPTION
When combining border-color(rgba) and background-image together, the alpha in border-color also has an unexpected influence on background-image due to border and background-image share the same paint.

Refer http://dotwe.org/vue/d97477731dd85fedb3970fb106953fb9 to see a demo.