### PR TITLE
Jsfm setup function

### DIFF
--- a/html5/render/native/index.js
+++ b/html5/render/native/index.js
@@ -16,36 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { subversion } from '../../../package.json'
-import runtime from '../../runtime'
+import setup from './setup'
 import frameworks from '../../frameworks/index'
-import services from '../../services/index'
 
-const { init, config } = runtime
-config.frameworks = frameworks
-const { native, transformer } = subversion
-
-for (const serviceName in services) {
-  runtime.service.register(serviceName, services[serviceName])
-}
-
-runtime.freezePrototype()
-runtime.setNativeConsole()
-
-// register framework meta info
-global.frameworkVersion = native
-global.transformerVersion = transformer
-
-// init frameworks
-const globalMethods = init(config)
-
-// set global methods
-for (const methodName in globalMethods) {
-  global[methodName] = (...args) => {
-    const ret = globalMethods[methodName](...args)
-    if (ret instanceof Error) {
-      console.error(ret.toString())
-    }
-    return ret
-  }
-}
+setup(frameworks)

--- a/html5/render/native/setup.js
+++ b/html5/render/native/setup.js
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { subversion } from '../../../package.json'
+import runtime from '../../runtime'
+import services from '../../services/index'
+
+/**
+ * Setup frameworks with runtime.
+ * You can package more frameworks by
+ *  passing them as arguments.
+ */
+export default function (frameworks) {
+  const { init, config } = runtime
+  config.frameworks = frameworks
+  const { native, transformer } = subversion
+
+  for (const serviceName in services) {
+    runtime.service.register(serviceName, services[serviceName])
+  }
+
+  runtime.freezePrototype()
+  runtime.setNativeConsole()
+
+  // register framework meta info
+  global.frameworkVersion = native
+  global.transformerVersion = transformer
+
+  // init frameworks
+  const globalMethods = init(config)
+
+  // set global methods
+  for (const methodName in globalMethods) {
+    global[methodName] = (...args) => {
+      const ret = globalMethods[methodName](...args)
+      if (ret instanceof Error) {
+        console.error(ret.toString())
+      }
+      return ret
+    }
+  }
+}
+


### PR DESCRIPTION
Move setup to a seperate file.    
Default weex project will setup frameworks under `../../frameworks/index`. In some custom case, you can use whatever you want by pass the frameworks as arguments to  this `setup` function.