### PR TITLE
* [ios] add pagingEnabled attribute for scroller component

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
@@ -65,6 +65,7 @@
     // left & right & up & down
     NSString *_direction;
     BOOL _showScrollBar;
+    BOOL _pagingEnabled;
 
     css_node_t *_scrollerCSSNode;
     
@@ -106,6 +107,7 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
         _lastScrollEventFiredOffset = CGPointMake(0, 0);
         _scrollDirection = attributes[@"scrollDirection"] ? [WXConvert WXScrollDirection:attributes[@"scrollDirection"]] : WXScrollDirectionVertical;
         _showScrollBar = attributes[@"showScrollbar"] ? [WXConvert BOOL:attributes[@"showScrollbar"]] : YES;
+        _pagingEnabled = attributes[@"pagingEnabled"] ? [WXConvert BOOL:attributes[@"pagingEnabled"]] : NO;
         _loadMoreOffset = attributes[@"loadmoreoffset"] ? [WXConvert WXPixelType:attributes[@"loadmoreoffset"] scaleFactor:self.weexInstance.pixelScaleFactor] : 0;
         _loadmoreretry = attributes[@"loadmoreretry"] ? [WXConvert NSUInteger:attributes[@"loadmoreretry"]] : 0;
         _listenLoadMore = [events containsObject:@"loadmore"];
@@ -135,7 +137,6 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
 {
     [self setContentSize:_contentSize];
     UIScrollView* scrollView = (UIScrollView *)self.view;
-    scrollView.scrollEnabled = YES;
     scrollView.delegate = self;
     scrollView.exclusiveTouch = YES;
     scrollView.autoresizesSubviews = NO;
@@ -143,6 +144,7 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
     scrollView.showsVerticalScrollIndicator = _showScrollBar;
     scrollView.showsHorizontalScrollIndicator = _showScrollBar;
     scrollView.scrollEnabled = _scrollable;
+    scrollView.pagingEnabled = _pagingEnabled;
     
     if (self.ancestorScroller) {
         scrollView.scrollsToTop = NO;
@@ -181,6 +183,11 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
         _showScrollBar = [WXConvert BOOL:attributes[@"showScrollbar"]];
         ((UIScrollView *)self.view).showsHorizontalScrollIndicator = _showScrollBar;
         ((UIScrollView *)self.view).showsVerticalScrollIndicator = _showScrollBar;
+    }
+    
+    if (attributes[@"pagingEnabled"]) {
+        _pagingEnabled = [WXConvert BOOL:attributes[@"pagingEnabled"]];
+        ((UIScrollView *)self.view).pagingEnabled = _pagingEnabled;
     }
     
     if (attributes[@"loadmoreoffset"]) {


### PR DESCRIPTION
iOS UIScrollView's built-in pagingEnabled feature is more natural than using pan gesture.