### PR TITLE
[android]  js exception adapter change to list. so that can handler m…

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/WXSDKEngine.java
+++ b/android/sdk/src/main/java/com/taobao/weex/WXSDKEngine.java
@@ -207,7 +207,7 @@ public class WXSDKEngine {
   }
 
   public static void setJSExcetptionAdapter(IWXJSExceptionAdapter excetptionAdapter){
-    WXSDKManager.getInstance().setIWXJSExceptionAdapter(excetptionAdapter);
+    WXSDKManager.getInstance().addIWXJSExceptionAdapter(excetptionAdapter);
   }
 
   private static void register() {

--- a/android/sdk/src/main/java/com/taobao/weex/WXSDKManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/WXSDKManager.java
@@ -51,6 +51,7 @@ import com.taobao.weex.utils.WXLogUtils;
 import com.taobao.weex.utils.WXUtils;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +78,7 @@ public class WXSDKManager {
 
   private ICrashInfoReporter mCrashInfo;
 
-  private IWXJSExceptionAdapter mIWXJSExceptionAdapter;
+  private List<IWXJSExceptionAdapter> mIWXJSExceptionAdapters;
 
   private IWXStorageAdapter mIWXStorageAdapter;
   private IWXStatisticsListener mStatisticsListener;
@@ -298,12 +299,39 @@ public class WXSDKManager {
     return mDrawableLoader;
   }
 
+  /**
+   * use getIWXJSExceptionAdapters instead.
+   */
+  @Deprecated
   public IWXJSExceptionAdapter getIWXJSExceptionAdapter() {
-    return mIWXJSExceptionAdapter;
+    return mIWXJSExceptionAdapters != null && mIWXJSExceptionAdapters.size() > 0 ? mIWXJSExceptionAdapters.get(0) : null;
   }
 
+  @Nullable
+  public List<IWXJSExceptionAdapter> getIWXJSExceptionAdapters() {
+    return mIWXJSExceptionAdapters;
+  }
+
+  /**
+   * use addIWXJSExceptionAdapter instead
+   * @param IWXJSExceptionAdapter
+   */
+  @Deprecated
   void setIWXJSExceptionAdapter(IWXJSExceptionAdapter IWXJSExceptionAdapter) {
-    mIWXJSExceptionAdapter = IWXJSExceptionAdapter;
+    addIWXJSExceptionAdapter(IWXJSExceptionAdapter);
+  }
+
+  void addIWXJSExceptionAdapter(IWXJSExceptionAdapter adapter) {
+
+    if(null == mIWXJSExceptionAdapters) {
+      synchronized (WXSDKManager.class) {
+        if (null == mIWXJSExceptionAdapters) {
+          mIWXJSExceptionAdapters = new ArrayList<>();
+        }
+      }
+    }
+
+    mIWXJSExceptionAdapters.add(adapter);
   }
 
   public @NonNull IWXHttpAdapter getIWXHttpAdapter() {
@@ -333,7 +361,7 @@ public class WXSDKManager {
     this.mIWXUserTrackAdapter = config.getUtAdapter();
     this.mURIAdapter = config.getURIAdapter();
     this.mIWebSocketAdapterFactory = config.getWebSocketAdapterFactory();
-    this.mIWXJSExceptionAdapter = config.getJSExceptionAdapter();
+    addIWXJSExceptionAdapter(config.getJSExceptionAdapter());
     this.mIWXSoLoaderAdapter = config.getIWXSoLoaderAdapter();
   }
 

--- a/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
@@ -1186,10 +1186,16 @@ public class WXBridgeManager implements Callback,BactchExecutor {
       String err = "function:" + function + "#exception:" + exception;
       commitJSBridgeAlarmMonitor(instanceId, WXErrorCode.WX_ERR_JS_EXECUTE, err);
 
-      IWXJSExceptionAdapter adapter = WXSDKManager.getInstance().getIWXJSExceptionAdapter();
-      if (adapter != null) {
+      List<IWXJSExceptionAdapter> adapterList = WXSDKManager.getInstance().getIWXJSExceptionAdapters();
+      if (adapterList != null) {
         WXJSExceptionInfo jsException = new WXJSExceptionInfo(instanceId, instance.getBundleUrl(), WXErrorCode.WX_ERR_JS_EXECUTE.getErrorCode(), function, exception, null);
-        adapter.onJSException(jsException);
+        for(IWXJSExceptionAdapter adapter : adapterList) {
+          try {
+            adapter.onJSException(jsException);
+          } catch (Throwable e) {
+            // ignore adapter's exception
+          }
+        }
         if (WXEnvironment.isApkDebugable()) {
           WXLogUtils.d(jsException.toString());
         }


### PR DESCRIPTION
[android] js exception adapter change to list. so that can handler more than one listener.   

Now faced a problem is 
WeexErrorCallback (used by Motu weex js exception caught) 
**is conflict with** 
JSExceptionGlobalEventReport (added in taobao_weex_adapter to caught js exception and throw it to js, we use JSTracker to log exceptions.)
