### PR TITLE
* [ios] add force touch `force` value for touch event

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
@@ -468,8 +468,6 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
         _direction = @"up";
         [self handleLoadMore];
     }
-   
-    _lastContentOffset = scrollView.contentOffset;
     
     CGFloat scaleFactor = self.weexInstance.pixelScaleFactor;
     [_refreshComponent pullingdown:@{
@@ -478,7 +476,8 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
              REFRESH_PULLINGDISTANCE: @(scrollView.contentOffset.y/scaleFactor),
              @"type":@"pullingdown"
     }];
-
+    _lastContentOffset = scrollView.contentOffset;
+    
     // check sticky
     [self adjustSticky];
     [self handleAppear];

--- a/ios/sdk/WeexSDK/Sources/Events/WXComponent+Events.m
+++ b/ios/sdk/WeexSDK/Sources/Events/WXComponent+Events.m
@@ -760,7 +760,21 @@ if ([removeEventName isEqualToString:@#eventName]) {\
             touch.wx_identifier = @(_touchIdentifier++);
         }
         NSDictionary *resultTouch = [_component touchResultWithScreenLocation:screenLocation pageLocation:pageLocation identifier:touch.wx_identifier];
-        [resultTouches addObject:resultTouch];
+        NSMutableDictionary * mutableResultTouch = [resultTouch mutableCopy];
+        if (WX_SYS_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9.0")) {
+            NSLog(@"touch force: %lf, maximum:%lf", touch.force, touch.maximumPossibleForce);
+            float value = touch.force*60;
+            float maxValue = touch.maximumPossibleForce*60;
+            if (touch.maximumPossibleForce) {
+                // the forece value will be range 1 from 0.
+                [mutableResultTouch setObject:[NSNumber numberWithFloat:value/maxValue] forKey:@"force"];
+            }else {
+                [mutableResultTouch setObject:[NSNumber numberWithFloat:0.0] forKey:@"force"];
+            }
+            
+        }
+        
+        [resultTouches addObject:mutableResultTouch];
     }
     
     [_component fireEvent:eventName params:@{@"changedTouches":resultTouches ?: @[]}];

--- a/ios/sdk/WeexSDK/Sources/Events/WXComponent+Events.m
+++ b/ios/sdk/WeexSDK/Sources/Events/WXComponent+Events.m
@@ -761,8 +761,8 @@ if ([removeEventName isEqualToString:@#eventName]) {\
         }
         NSDictionary *resultTouch = [_component touchResultWithScreenLocation:screenLocation pageLocation:pageLocation identifier:touch.wx_identifier];
         NSMutableDictionary * mutableResultTouch = [resultTouch mutableCopy];
+        
         if (WX_SYS_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9.0")) {
-            NSLog(@"touch force: %lf, maximum:%lf", touch.force, touch.maximumPossibleForce);
             float value = touch.force*60;
             float maxValue = touch.maximumPossibleForce*60;
             if (touch.maximumPossibleForce) {
@@ -771,7 +771,6 @@ if ([removeEventName isEqualToString:@#eventName]) {\
             }else {
                 [mutableResultTouch setObject:[NSNumber numberWithFloat:0.0] forKey:@"force"];
             }
-            
         }
         
         [resultTouches addObject:mutableResultTouch];


### PR DESCRIPTION
add force value for touchEvent, [w3c](https://github.com/w3c/touch-events/pull/81) document
about [touch](https://w3c.github.io/touch-events/#widl-Touch-force) update it about a month ago,

note: the force value is range `0` to `1`, where 0 is no pressure, and 1 is the highest level of pressure the touch device is capable of sensing; 0 if no value is known. In environments where force is known, the absolute pressure represented by the force attribute, and the sensitivity in levels of pressure, may vary.

case: http://dotwe.org/weex/653ec363683c3c69bf2884c6eb7f061d