### PR TITLE
+ [ios] fix bug: when add IndicatorView  lazy . the IndicatorView can…

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXCycleSliderComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXCycleSliderComponent.m
@@ -431,6 +431,7 @@ typedef NS_ENUM(NSInteger, Direction) {
         if ([view isKindOfClass:[WXIndicatorView class]]) {
             ((WXIndicatorComponent *)subcomponent).delegate = self;
             [recycleSliderView addSubview:view];
+            [self setIndicatorView:(WXIndicatorView *)view];
             return;
         }
         

--- a/ios/sdk/WeexSDK/Sources/Component/WXSliderComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXSliderComponent.m
@@ -449,6 +449,7 @@
         if ([view isKindOfClass:[WXIndicatorView class]]) {
             ((WXIndicatorComponent *)subcomponent).delegate = self;
             [sliderView addSubview:view];
+            [self setIndicatorView:(WXIndicatorView *)view];
             return;
         }
         


### PR DESCRIPTION
[ios] fix bug: when add IndicatorView lazy . the IndicatorView can not create in slider successfully
because slider component change to delegate last time. the delegate maybe nil when view Lazy loading

test case：http://rax.alibaba-inc.com/playground/584f5e36-589d-4164-90eb-2a1a95c10174