### PR TITLE
* [android] Use pair in android.util.pair.

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/utils/WXResourceUtils.java
+++ b/android/sdk/src/main/java/com/taobao/weex/utils/WXResourceUtils.java
@@ -22,7 +22,7 @@ import android.graphics.Color;
 import android.graphics.LinearGradient;
 import android.graphics.Shader;
 import android.support.annotation.NonNull;
-import android.support.v4.util.Pair;
+import android.util.Pair;
 import android.text.TextUtils;
 
 import java.util.ArrayList;


### PR DESCRIPTION
As support-v4 actually supports api 9 from support library [24.2.0 and higher](https://developer.android.com/topic/libraries/support-library/index.html#api-versions). Any class reference in v4 library that is expected to work lower than API 9 and higher than API 4 should be [migrated](https://developer.android.com/topic/libraries/support-library/rev-archive.html).