### PR TITLE
[jsfm] Fix the console API to adapt JSC on Android

### DIFF
--- a/html5/shared/console.js
+++ b/html5/shared/console.js
@@ -39,7 +39,7 @@ export function setNativeConsole () {
 
   /* istanbul ignore next */
   if (
-    typeof global.console === 'undefined' || // Android
+    // typeof global.console === 'undefined' || // Android // remove android hack
     (global.WXEnvironment && global.WXEnvironment.platform === 'iOS') // iOS
   ) {
     global.console = {

--- a/html5/shared/console.js
+++ b/html5/shared/console.js
@@ -38,10 +38,8 @@ export function setNativeConsole () {
   generateLevelMap()
 
   /* istanbul ignore next */
-  if (
-    // typeof global.console === 'undefined' || // Android // remove android hack
-    (global.WXEnvironment && global.WXEnvironment.platform === 'iOS') // iOS
-  ) {
+  // mock console in native environment
+  if (global.WXEnvironment && global.WXEnvironment.platform !== 'Web') {
     global.console = {
       debug: (...args) => {
         if (checkLevel('debug')) { global.nativeLog(...format(args), '__DEBUG') }
@@ -60,7 +58,9 @@ export function setNativeConsole () {
       }
     }
   }
-  else { // HTML5 or Node
+
+  // Web or Node
+  else {
     const { debug, log, info, warn, error } = console
     console.__ori__ = { debug, log, info, warn, error }
     console.debug = (...args) => {


### PR DESCRIPTION
As Weex switched its js engine to JSC on Android, the legacy hack of the console should be removed.