### PR TITLE
[example] Modify the countdown example

### DIFF
--- a/examples/vue/components/countdown.vue
+++ b/examples/vue/components/countdown.vue
@@ -1,7 +1,7 @@
 <template>
   <scroller>
     <panel title="Countdown" type="primary">
-      <countdown
+      <count-down
         @tick="tick($event, 'countdown1')"
         :remain="countdown1.remain"
         style="width: 750; margin-top: 20; margin-bottom: 20;">
@@ -13,16 +13,16 @@
         <text class="ctno1" style="background-color: #FFFFFF; color: #AAAAAA;">minute(s)</text>
         <text class="ctno1">{{countdown1.time.ss}}</text>
         <text class="ctno1" style="background-color: #FFFFFF; color: #AAAAAA;">second(s)</text>
-      </countdown>
+      </count-down>
 
-      <countdown
+      <count-down
         @tick="tick($event, 'countdown2')"
         :remain="countdown2.remain"
         style="width: 600;">
         <text class="ctno2">{{countdown2.time.MM}}</text>
         <text class="ctno2" style="background-color: #FFFFFF; color: #AAAAAA;">:</text>
         <text class="ctno2">{{countdown2.time.ss}}</text>
-      </countdown>
+      </count-down>
     </panel>
   </scroller>
 </template>
@@ -77,7 +77,7 @@
     },
     components: {
       panel: require('../include/panel.vue'),
-      countdown: require('../include/countdown.vue')
+      'count-down': require('../include/countdown.vue')
     },
     methods: {
       tick: function (e, k) {


### PR DESCRIPTION
Rename `countdown` to `count-down`, because "countdown" is reserved tag name in weex-vue-framework.