### PR TITLE
[doc] Add documents for "weex.supports" API

### DIFF
--- a/doc/source/cn/references/weex-variable.md
+++ b/doc/source/cn/references/weex-variable.md
@@ -45,3 +45,48 @@ has_chapter_content: true
 ## `weex.document: Document`
 
 返回当前 Weex 页面的文档对象。
+
+## `weex.supports`
+<span class="weex-version">v0.15+</span>
+
+`weex.supports` 可以用来检测当前环境中是否支持某个特性。
+
+### API
+
+```js
+weex.supports(condition : String) : Boolean | Null
+```
+
+#### 参数
+
++ 特定格式的字符串：`@{type}/{name}`。
+
+`type` 必须是 "component" 或者 "module"。`name` 可以是标签名、模块名，也可以指定模块中的某个方法名（和模块名用 `.` 隔开）。
+
+#### 返回值
+
++ 支持，则返回 `true`。
++ 不支持，则返回 `false`。
++ 参数格式错误或无法确定是否支持，则返回 `null`。
+
+### 例子
+
+```js
+// 检测是否支持某个组件
+weex.supports('@component/slider') // true
+weex.supports('@component/my-tab') // false
+
+// 检测是否支持某个模块
+weex.supports('@module/stream')  // true
+weex.supports('@module/abcdef')  // false
+
+// 检测是否支持模块中的某个方法
+weex.supports('@module/dom.getComponentRect') // true
+weex.supports('@module/navigator.jumpToPage') // false
+
+// 无效的输入
+weex.supports('div') // null
+weex.supports('module/*') // null
+weex.supports('@stream/fetch') // null
+weex.supports('getComponentRect') // null
+```

--- a/doc/source/cn/references/weex-variable.md
+++ b/doc/source/cn/references/weex-variable.md
@@ -47,9 +47,12 @@ has_chapter_content: true
 返回当前 Weex 页面的文档对象。
 
 ## `weex.supports`
+
 <span class="weex-version">v0.15+</span>
 
 `weex.supports` 可以用来检测当前环境中是否支持某个特性。
+
+> 目前仅在 Weex DSL 2.0 (.vue) 中支持。
 
 ### API
 

--- a/doc/source/references/weex-variable.md
+++ b/doc/source/references/weex-variable.md
@@ -48,7 +48,11 @@ Returns the document object of the current Weex page.
 
 ## `weex.supports`
 
+<span class="weex-version">v0.15+</span>
+
 `weex.supports` is a method used to detect whether a feature is supported in the current environment.
+
+> Only supported in Weex DSL 2.0 (.vue).
 
 ### API
 

--- a/doc/source/references/weex-variable.md
+++ b/doc/source/references/weex-variable.md
@@ -9,7 +9,7 @@ version: 2.1
 
 Each Weex page has a separate weex variable, which exists in the JS context. They hold a single instance or method of the current Weex page.   
 
-`weex.config`
+## `weex.config`
 
 This variable contains all the environment information for the current Weex page, including not only:       
 
@@ -42,6 +42,50 @@ Get all the methods of a native module, such as:
 ```   
 
 
-`weex.document: Document` 
+## `weex.document: Document`
 
 Returns the document object of the current Weex page.
+
+## `weex.supports`
+
+`weex.supports` is a method used to detect whether a feature is supported in the current environment.
+
+### API
+
+```js
+weex.supports(condition : String) : Boolean | Null
+```
+
+#### Parameter
+
++ a formatted string: `@{type}/{name}`.
+
+The `type` must be "component" or "module", the `name` can be tag name, module name or the method name in specific module.
+
+#### Return Value
+
++ if supported, returns `true`.
++ if unsupported, returns `false`.
++ if unclear, returns `null`.
+
+### Example
+
+```js
+// Detects whether the specific component is supported
+weex.supports('@component/slider') // true
+weex.supports('@component/my-tab') // false
+
+// Detects whether the specific module is supported
+weex.supports('@module/stream')  // true
+weex.supports('@module/abcdef')  // false
+
+// Detects whether the method in specific module is supported
+weex.supports('@module/dom.getComponentRect') // true
+weex.supports('@module/navigator.jumpToPage') // false
+
+// invalid input
+weex.supports('div') // null
+weex.supports('module/*') // null
+weex.supports('@stream/fetch') // null
+weex.supports('getComponentRect') // null
+```


### PR DESCRIPTION
The `weex.supports` API will be added in v0.15, and only supported in Weex DSL 2.0 (.vue).