### PR TITLE
[iOS] fix WXCycleSliderComponent initial index

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXCycleSliderComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXCycleSliderComponent.m
@@ -463,7 +463,7 @@ typedef NS_ENUM(NSInteger, Direction) {
             
             // check if should apply current contentOffset
             // in case inserting subviews after layoutDidFinish
-            if (index-offset == _index) {
+            if (index-offset == _index && _index>0) {
                 recycleSliderView.currentIndex = _index;
             }
         }

--- a/ios/sdk/WeexSDK/Sources/Component/WXCycleSliderComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXCycleSliderComponent.m
@@ -460,6 +460,12 @@ typedef NS_ENUM(NSInteger, Direction) {
                 }
             }
             [recycleSliderView insertItemView:view atIndex:index - offset];
+            
+            // check if should apply current contentOffset
+            // in case inserting subviews after layoutDidFinish
+            if (index-offset == _index) {
+                recycleSliderView.currentIndex = _index;
+            }
         }
         [recycleSliderView layoutSubviews];
     }


### PR DESCRIPTION
bug fix: initial index of WXCycleSliderComponent may be incorrect if
inserting subviews after layoutDidFinish (occurs when creating
time-consuming subview/components)