### PR TITLE
+[ios] 0.16-dev update code for component/module validation

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Bridge/WXBridgeContext.m
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXBridgeContext.m
@@ -325,7 +325,7 @@ _Pragma("clang diagnostic pop") \
             return nil;
         }
         
-        WXModuleMethod *method = [[WXModuleMethod alloc] initWithModuleName:moduleName methodName:methodName arguments:arguments instance:instance];
+        WXModuleMethod *method = [[WXModuleMethod alloc] initWithModuleName:moduleName methodName:methodName arguments:arguments options:options instance:instance];
         if(![moduleName isEqualToString:@"dom"] && instance.needPrerender){
             [WXPrerenderManager storePrerenderModuleTasks:method forUrl:instance.scriptURL.absoluteString];
             return nil;
@@ -396,7 +396,8 @@ _Pragma("clang diagnostic pop") \
             [WXTracingManager startTracingWithInstanceId:instanceId ref:task[@"ref"] className:nil name:task[@"component"] phase:WXTracingBegin functionName:task[@"method"] options:nil];
         } else {
             NSString *moduleName = task[@"module"];
-            WXModuleMethod *method = [[WXModuleMethod alloc] initWithModuleName:moduleName methodName:methodName arguments:arguments instance:instance];
+            NSDictionary *options = task[@"options"];
+            WXModuleMethod *method = [[WXModuleMethod alloc] initWithModuleName:moduleName methodName:methodName arguments:arguments options:options instance:instance];
             [WXTracingManager startTracingWithInstanceId:instanceId ref:nil className:nil name:task[@"module"] phase:WXTracingBegin functionName:task[@"method"] options:nil];
             [method invoke];
         }

--- a/ios/sdk/WeexSDK/Sources/Bridge/WXModuleMethod.h
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXModuleMethod.h
@@ -28,10 +28,12 @@ typedef enum : NSUInteger {
 
 @property (nonatomic, assign) WXModuleMethodType methodType;
 @property (nonatomic, strong, readonly) NSString *moduleName;
+@property (nonatomic, strong, readonly) NSDictionary *options;
 
 - (instancetype)initWithModuleName:(NSString *)moduleName
                         methodName:(NSString *)methodName
                          arguments:(NSArray *)arguments
+                           options:(NSDictionary *)options
                           instance:(WXSDKInstance *)instance;
 
 - (NSInvocation *)invoke;

--- a/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.m
@@ -40,8 +40,6 @@
 static NSThread *WXComponentThread;
 
 #define WXAssertComponentExist(component)  WXAssert(component, @"component not exists")
-#define WXAUTH_ISV_COMPONENT_TAG    @"isv-div"
-#define WXAUTH_ISV_COMPONENT_KEY    @"isvAppKey"
 
 @implementation WXComponentManager
 {

--- a/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
+++ b/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
@@ -157,6 +157,8 @@ typedef enum : NSUInteger {
     _options = options;
     _jsData = data;
     
+    self.needValidate = [[WXHandlerFactory handlerForProtocol:@protocol(WXValidateProtocol)] needValidate:self.scriptURL];
+    
     [self _renderWithMainBundleString:source];
     
     [WXTracingManager setBundleJSType:source instanceId:self.instanceId];

--- a/ios/sdk/WeexSDK/Sources/Protocol/WXValidateProtocol.h
+++ b/ios/sdk/WeexSDK/Sources/Protocol/WXValidateProtocol.h
@@ -43,8 +43,8 @@
 
 -(BOOL)needValidate:(NSURL*) bundleUrl;
 
--(WXModuleValidateResult *)validateWithWXSDKInstance:(WXSDKInstance *)wxsdkInstance module:(NSString*) moduel method:(NSString *)method args:(NSArray *)args;
+-(WXModuleValidateResult *)validateWithWXSDKInstance:(WXSDKInstance *)wxsdkInstance module:(NSString*) moduel method:(NSString *)method args:(NSArray *)args options:(NSDictionary *)options;
 
--(WXComponentValidateResult *)validateWithWXSDKInstance:(WXSDKInstance *)wxsdkInstance component:(NSString *)componentName;
+-(WXComponentValidateResult *)validateWithWXSDKInstance:(WXSDKInstance *)wxsdkInstance component:(NSString *)componentName supercomponent:(WXComponent *)supercomponent;
 
 @end


### PR DESCRIPTION
Add `options` for module validation to get `isvAppKey`. For component validation, `isvAppKey` would be fetched from `superComponent`.