### PR TITLE
fix: gcanvas example support to html5

### DIFF
--- a/examples/vue/market/gcanvas.vue
+++ b/examples/vue/market/gcanvas.vue
@@ -1,15 +1,19 @@
 <template>
   <div ref="test">
-    <gcanvas ref="canvas_holder" style="width:750;height:750;"></gcanvas>
+    <component :is="tagName" width="750" height="750" ref="canvas_holder" style="width:750px;height:750px;"></component>
   </div>
 </template>
 <script>
-  //	var gcanvas = weex.requireModule('weex-gcanvas');
 
   var GCanvas=require('weex-gcanvas');
   var Image=require('weex-gcanvas/gcanvasimage');
 
   module.exports = {
+    data() {
+      return {
+        tagName: weex.config.env.platform === 'Web' ? 'canvas' : 'gcanvas'
+      }
+    },
     mounted: function () {
       var ref = this.$refs.canvas_holder;
       var gcanvas = GCanvas.start(ref)


### PR DESCRIPTION
1.  h5, `weex-gcanvas` does not recognize the gcanvas tag because the` weex-gcanvas` library can not be coupled to vue so that the gcanvas tag can not be registered. Need to judge.
2.  We need to set the `width` and` height` attributes of the canvas tag, otherwise the display is incorrect.

> weex-gcanvas version should be more than the 0.5.2