### PR TITLE
* [android] The timer in Android will supports float interval/delay

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/module/WXTimerModule.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/module/WXTimerModule.java
@@ -27,6 +27,7 @@ import static com.taobao.weex.common.WXJSBridgeMsgType.MODULE_TIMEOUT;
 
 import android.os.Handler;
 import android.os.Message;
+import android.support.annotation.FloatRange;
 import android.support.annotation.IntDef;
 import android.support.annotation.IntRange;
 import android.support.annotation.VisibleForTesting;
@@ -63,16 +64,16 @@ public class WXTimerModule extends WXModule implements Destroyable, Handler.Call
 
 
   @JSMethod(uiThread = false)
-  public void setTimeout(@IntRange(from = 1) int funcId, @IntRange(from = 0) int delay) {
+  public void setTimeout(@IntRange(from = 1) int funcId, @FloatRange(from = 0) float delay) {
     if(mWXSDKInstance != null) {
-      postOrHoldMessage(MODULE_TIMEOUT, funcId, delay, Integer.parseInt(mWXSDKInstance.getInstanceId()));
+      postOrHoldMessage(MODULE_TIMEOUT, funcId, (int) delay, Integer.parseInt(mWXSDKInstance.getInstanceId()));
     }
   }
 
   @JSMethod(uiThread = false)
-  public void setInterval(@IntRange(from = 1) int funcId, @IntRange(from = 0) int interval) {
+  public void setInterval(@IntRange(from = 1) int funcId, @FloatRange(from = 0) float interval) {
     if(mWXSDKInstance != null) {
-      postOrHoldMessage(MODULE_INTERVAL, funcId, interval, Integer.parseInt(mWXSDKInstance.getInstanceId()));
+      postOrHoldMessage(MODULE_INTERVAL, funcId, (int) interval, Integer.parseInt(mWXSDKInstance.getInstanceId()));
     }
   }
 

--- a/android/sdk/src/test/java/com/taobao/weex/ui/module/WXTimerModuleTest.java
+++ b/android/sdk/src/test/java/com/taobao/weex/ui/module/WXTimerModuleTest.java
@@ -18,6 +18,8 @@
  */
 package com.taobao.weex.ui.module;
 
+import static android.R.attr.end;
+import static android.R.attr.start;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
@@ -61,6 +63,7 @@ public class WXTimerModuleTest {
   public final static int DELAY = 50;
   public final static int IMMEDIATELY = 0;
   public final static int INVALID_DELAY = -50;
+  public final static float FLOAT_DELAY = 20.6f;
 
   @Rule
   public PowerMockRule rule = new PowerMockRule();
@@ -84,7 +87,26 @@ public class WXTimerModuleTest {
   @Test
   public void testSetTimeoutDelay() throws Exception {
     module.setTimeout(VALID_FUNC_ID, DELAY);
-    mLooper.idle(DELAY);
+    long start, end, duration;
+    start = mLooper.getScheduler().getCurrentTime();
+    mLooper.runOneTask();
+    end = mLooper.getScheduler().getCurrentTime();
+    duration = end - start;
+
+    assertThat(duration, is((long) DELAY));
+    Mockito.verify(module, times(1)).handleMessage(any(Message.class));
+  }
+
+  @Test
+  public void testSetTimeoutDelay2() throws Exception {
+    module.setTimeout(VALID_FUNC_ID, FLOAT_DELAY);
+    long start, end, duration;
+    start = mLooper.getScheduler().getCurrentTime();
+    mLooper.runOneTask();
+    end = mLooper.getScheduler().getCurrentTime();
+    duration = end - start;
+
+    assertThat(duration, is((long) FLOAT_DELAY));
     Mockito.verify(module, times(1)).handleMessage(any(Message.class));
   }
 
@@ -164,6 +186,23 @@ public class WXTimerModuleTest {
   }
 
   @Test
+  public void testSetIntervalDelay2() {
+    long start, end, duration;
+    module.setInterval(VALID_FUNC_ID, FLOAT_DELAY);
+
+    start = mLooper.getScheduler().getCurrentTime();
+    mLooper.runOneTask();
+    end = mLooper.getScheduler().getCurrentTime();
+    duration = end - start;
+
+    assertThat(duration, is((long) FLOAT_DELAY));
+
+    mLooper.runOneTask();
+    mLooper.runOneTask();
+    Mockito.verify(module, times(3)).handleMessage(any(Message.class));
+  }
+
+  @Test
   public void testClearTimeout() throws Exception {
     module.setTimeout(VALID_FUNC_ID, DELAY);
     module.clearTimeout(VALID_FUNC_ID);
@@ -180,7 +219,7 @@ public class WXTimerModuleTest {
   }
 
   @Test
-  public void setClearTimeout2(){
+  public void testClearTimeout2(){
     module.setTimeout(NO_CACHING_FUNC_ID, DELAY);
     module.clearTimeout(NO_CACHING_FUNC_ID);
     mLooper.idle(DELAY, TimeUnit.MILLISECONDS);
@@ -188,7 +227,7 @@ public class WXTimerModuleTest {
   }
 
   @Test
-  public void setClearInterval2(){
+  public void testClearInterval2(){
     module.setInterval(NO_CACHING_FUNC_ID, DELAY);
     module.clearInterval(NO_CACHING_FUNC_ID);
     mLooper.idle(DELAY, TimeUnit.MILLISECONDS);

--- a/test/pages/modules/vue_timer.vue
+++ b/test/pages/modules/vue_timer.vue
@@ -1,14 +1,14 @@
 <template>
     <div>
         <text>setTimeout timeout=3000</text>
-        <div class="wrapper">
+        <div class="wrapper-top">
             <text test-id="setTimeout" class="t" @click="stimeout">SetTimeOut</text>
             <text test-id="clearTimeout" class="t" @click="ctimeout">ClearTimeOut</text>
         </div>
         <text class="content" test-id="timeout">{{timeout_content}}</text>
 
         <text style="margin-top: 100px">setInterval interval=3000</text>
-        <div style="background-color:red" class="wrapper">
+        <div class="wrapper-bottom">
             <text test-id="setInterval" class="t" @click="sinterval">SetInterval</text>
             <text test-id="clearInterval" class="t" @click="cinterval">ClearInterval</text>
         </div>
@@ -17,10 +17,18 @@
 </template>
 
 <style>
-    .wrapper {
+    .wrapper-top {
         height: 100px;
         width: 750px;
         background-color: yellow;
+        align-items: center;
+        flex-direction: row
+    }
+    
+    .wrapper-bottom {
+        height: 100px;
+        width: 750px;
+        background-color: red;
         align-items: center;
         flex-direction: row
     }

--- a/test/pages/modules/we_timer.we
+++ b/test/pages/modules/we_timer.we
@@ -1,14 +1,14 @@
 <template>
     <div>
         <text>setTimeout timeout=5000</text>
-        <div class="wrapper">
+        <div class="wrapper-top">
             <text test-id="setTimeout" class="t" onclick="stimeout">SetTimeOut</text>
             <text test-id="clearTimeout" class="t" onclick="ctimeout">ClearTimeOut</text>
         </div>
         <text class="content" test-id="timeout">{{timeout_content}}</text>
 
         <text style="margin-top: 100px">setInterval interval=5000</text>
-        <div style="background-color:red" class="wrapper">
+        <div class="wrapper-bottom">
             <text test-id="setInterval" class="t" onclick="sinterval">SetInterval</text>
             <text test-id="clearInterval" class="t" onclick="cinterval">ClearInterval</text>
         </div>
@@ -17,10 +17,18 @@
 </template>
 
 <style>
-    .wrapper {
+    .wrapper-top {
         height: 100px;
         width: 750px;
         background-color: yellow;
+        align-items: center;
+        flex-direction: row
+    }
+    
+    .wrapper-bottom {
+        height: 100px;
+        width: 750px;
+        background-color: red;
         align-items: center;
         flex-direction: row
     }


### PR DESCRIPTION
The timer in Android will supports float interval/delay and transform them to int.

As some coders always ignore the docs and pass float value, which is not supported, the sdk has no way but to be tolerant with wrong behavior.

Refer <https://issues.apache.org/jira/browse/WEEX-68>