### PR TITLE
* [ios] change taskIdentifier’s reference to weak to avoid memory leak.

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Network/WXResourceRequest.h
+++ b/ios/sdk/WeexSDK/Sources/Network/WXResourceRequest.h
@@ -32,7 +32,7 @@ typedef enum : NSUInteger {
 
 @interface WXResourceRequest : NSMutableURLRequest
 
-@property (nonatomic, strong) id taskIdentifier;
+@property (nonatomic, weak) id taskIdentifier;
 @property (nonatomic, assign) WXResourceType type;
 
 @property (nonatomic, strong) NSString *referrer;


### PR DESCRIPTION
change taskIdentifier’s reference to weak to avoid memory leak.