### PR TITLE
fix: circular dependency in java classes（WXSDKManager and WXBridgeMan…

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/WXEnvironment.java
+++ b/android/sdk/src/main/java/com/taobao/weex/WXEnvironment.java
@@ -65,7 +65,7 @@ public class WXEnvironment {
    */
   public static boolean sDebugMode = false;
   public static String sDebugWsUrl = "";
-  public static boolean sDebugServerConnectable = true;
+  public static boolean sDebugServerConnectable = false;
   public static boolean sRemoteDebugMode = false;
   public static String sRemoteDebugProxyUrl = "";
   public static long sJSLibInitTime = 0;


### PR DESCRIPTION
```bash
at com.taobao.weex.WXSDKManager.getInstance(WXSDKManager.java:155)
at com.taobao.weex.devtools.WeexInspector.initialize(WeexInspector.java:106)
at com.taobao.weex.devtools.WeexInspector.initializeWithDefaults(WeexInspector.java:81)
at com.taobao.weex.devtools.debug.DebugServerProxy.start(DebugServerProxy.java:96)
at com.taobao.weex.bridge.WXBridgeManager.initWXBridge(WXBridgeManager.java:197)
at com.taobao.weex.bridge.WXBridgeManager.<init>(WXBridgeManager.java:163)
at com.taobao.weex.bridge.WXBridgeManager.getInstance(WXBridgeManager.java:172)
at com.taobao.weex.WXSDKManager.<init>(WXSDKManager.java:99)
at com.taobao.weex.WXSDKManager.<init>(WXSDKManager.java:93)
at com.taobao.weex.WXSDKManager.getInstance(WXSDKManager.java:155)
at com.taobao.weex.devtools.WeexInspector.initialize(WeexInspector.java:106)
at com.taobao.weex.devtools.WeexInspector.initializeWithDefaults(WeexInspector.java:81)
at com.taobao.weex.devtools.debug.DebugServerProxy.start(DebugServerProxy.java:96)
at com.taobao.weex.bridge.WXBridgeManager.initWXBridge(WXBridgeManager.java:197)
at com.taobao.weex.bridge.WXBridgeManager.<init>(WXBridgeManager.java:163)
at com.taobao.weex.bridge.WXBridgeManager.getInstance(WXBridgeManager.java:172)
at com.taobao.weex.WXSDKManager.<init>(WXSDKManager.java:99)
at com.taobao.weex.WXSDKManager.<init>(WXSDKManager.java:93)
at com.taobao.weex.WXSDKManager.getInstance(WXSDKManager.java:155)
```


当开发者依赖weex_sdk和weex_inspector时，调用WXSDKEngine.initialize(application,config);时会因为
WXSDKManager 和 WXBridgeManager 会死循环递归调用彼此getInstance()，导致oom。可能的错误为：


```bash
W/art: Large object allocation failed: ashmem_create_region failed for 'large object space allocation': Too many open files
```

```bash
java.lang.OutOfMemoryError: Could not allocate JNI Env
```

```bash
Could not create epoll instance. errno=24
```

请参考：https://www.atatech.org/articles/91448