### PR TITLE
[WEEX-78] Replace "includes" with "indexOf" to improve compatibility

### DIFF
--- a/html5/runtime/vdom/Element.js
+++ b/html5/runtime/vdom/Element.js
@@ -409,7 +409,7 @@ export default class Element extends Node {
 
     if (!isStopPropagation
       && isBubble
-      && BUBBLE_EVENTS.includes(type)
+      && (BUBBLE_EVENTS.indexOf(type) !== -1)
       && this.parentNode
       && this.parentNode.fireEvent) {
       event.currentTarget = this.parentNode


### PR DESCRIPTION
### Problem

`Array.prototype.includes` is defined in ECMAScript 2016 (ES7) which is not compatible with low version js engines.

### Solution

Use `Array.prototype.indexOf` instead of `Array.prototype.includes`.