### PR TITLE
* [android] fix redundant input event

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/AbstractEditComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/AbstractEditComponent.java
@@ -221,6 +221,14 @@ public abstract class AbstractEditComponent extends WXComponent<WXEditText> {
 
           mBeforeText = s.toString();
 
+          if (getDomObject() != null && getDomObject().getAttrs() != null) {
+            Object val = getDomObject().getAttrs().get(Constants.Name.VALUE);
+            String valString = WXUtils.getString(val, null);
+            if (mBeforeText != null && mBeforeText.equals(valString)) {
+              return;
+            }
+          }
+
           if (!mIgnoreNextOnInputEvent) {
             fireEvent(Constants.Event.INPUT, s.toString());
           }


### PR DESCRIPTION
Fix the redundant `oninput` callback when default value to be seted
Testcase:
http://dotwe.org/vue/5ad804cd421805f7a2627cc81422a6e5