### PR TITLE
* [Android] Fix that moveElement doesn't work when parent is not a list

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/dom/action/MoveElementAction.java
+++ b/android/sdk/src/main/java/com/taobao/weex/dom/action/MoveElementAction.java
@@ -91,5 +91,8 @@ final class MoveElementAction implements DOMAction, RenderAction {
     WXVContainer oldParent = component.getParent();
     oldParent.remove(component,false);
     ((WXVContainer) newParent).addChild(component, mNewIndex);
+    if(!component.isVirtualComponent()){
+      ((WXVContainer) newParent).addSubView(component.getHostView(), mNewIndex);
+    }
   }
 }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXScroller.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXScroller.java
@@ -233,7 +233,7 @@ public class WXScroller extends WXVContainer<ViewGroup> implements WXScrollViewL
    * Intercept refresh view and loading view
    */
   @Override
-  protected void addSubView(View child, int index) {
+  public void addSubView(View child, int index) {
     if (child == null || getRealView() == null) {
       return;
     }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSlider.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSlider.java
@@ -173,7 +173,7 @@ public class WXSlider extends WXVContainer<FrameLayout> {
   }
 
   @Override
-  protected void addSubView(View view, int index) {
+  public void addSubView(View view, int index) {
     if (view == null || mAdapter == null) {
       return;
     }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSliderNeighbor.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSliderNeighbor.java
@@ -113,7 +113,7 @@ public class WXSliderNeighbor extends WXSlider {
     }
 
     @Override
-    protected void addSubView(View view, final int index) {
+    public void addSubView(View view, final int index) {
         if (view == null || mAdapter == null) {
             return;
         }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXVContainer.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXVContainer.java
@@ -20,6 +20,9 @@ package com.taobao.weex.ui.component;
 
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.RestrictTo;
+import android.support.annotation.RestrictTo.Scope;
+import android.util.Pair;
 import android.support.annotation.Nullable;
 import android.util.Pair;
 import android.view.Menu;
@@ -308,7 +311,8 @@ public abstract class WXVContainer<T extends ViewGroup> extends WXComponent<T> {
     }
   }
 
-  protected void addSubView(View child, int index) {
+  @RestrictTo(Scope.LIBRARY)
+  public void addSubView(View child, int index) {
     if (child == null || getRealView() == null) {
       return;
     }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/list/BasicListComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/list/BasicListComponent.java
@@ -706,7 +706,7 @@ public abstract class BasicListComponent<T extends ViewGroup & ListComponentView
    * com.taobao.weex.ui.view.listview.WXRecyclerView}
    */
   @Override
-  protected void addSubView(View child, int index) {
+  public void addSubView(View child, int index) {
 
   }
 

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/list/template/WXRecyclerTemplateList.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/list/template/WXRecyclerTemplateList.java
@@ -593,7 +593,7 @@ public class WXRecyclerTemplateList extends WXVContainer<BounceRecyclerView> imp
      * com.taobao.weex.ui.view.listview.WXRecyclerView}
      */
     @Override
-    protected void addSubView(View child, int index) {
+    public void addSubView(View child, int index) {
 
     }
 


### PR DESCRIPTION
 Fix that moveElement doesn't work when parent is not a list.

This bug may exist for more than two years.