### PR TITLE
* [android] fix wrong logic when set box-shadow on adapter view

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
@@ -866,7 +866,7 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
 
       View target = mHost;
       if (this instanceof WXVContainer) {
-        target = ((WXVContainer) this).getBoxShadowHost();
+        target = ((WXVContainer) this).getBoxShadowHost(false);
       }
 
       if (target == null) {
@@ -909,7 +909,7 @@ public abstract class  WXComponent<T extends View> implements IWXObject, IWXActi
   protected void clearBoxShadow() {
     View target = mHost;
     if (this instanceof WXVContainer) {
-      target = ((WXVContainer) this).getBoxShadowHost();
+      target = ((WXVContainer) this).getBoxShadowHost(true);
     }
 
     if (target != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXVContainer.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXVContainer.java
@@ -25,12 +25,11 @@ import android.util.Pair;
 import android.view.Menu;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.HorizontalScrollView;
-import android.widget.ScrollView;
 
 import com.taobao.weex.WXSDKInstance;
 import com.taobao.weex.common.Constants;
 import com.taobao.weex.dom.WXDomObject;
+import com.taobao.weex.ui.view.WXFrameLayout;
 import com.taobao.weex.utils.WXLogUtils;
 import com.taobao.weex.utils.WXViewUtils;
 
@@ -483,13 +482,18 @@ public abstract class WXVContainer<T extends ViewGroup> extends WXComponent<T> {
    *  end hook Activity life cycle callback
    ********************************************************/
 
-  public @Nullable View getBoxShadowHost() {
+  public @Nullable View getBoxShadowHost(boolean isClear) {
+    if (isClear) {
+      // Return existed host if want clear shadow
+      return mBoxShadowHost;
+    }
+
     ViewGroup hostView = getHostView();
     if (hostView == null) {
       return null;
     }
 
-    if (hostView instanceof ScrollView || hostView instanceof HorizontalScrollView) {
+    if (!(hostView instanceof WXFrameLayout)) {
       return hostView;
     }
 


### PR DESCRIPTION
Now we only add box-shadow view into WXFrameLayout

Testcase:
http://dotwe.org/vue/6bc1c6eae6ec927e1bd97c5ee2e18720