### PR TITLE
Remove maven central repository, use only jcenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 
 buildscript {
     repositories {
+        mavenLocal()
         jcenter()
     }
     dependencies {
@@ -14,15 +15,18 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
     jcenter()
 }
 
 subprojects {
     repositories {
+        mavenLocal()
         jcenter()
     }
     buildscript {
         repositories {
+            mavenLocal()
             jcenter()
         }
         dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,6 @@
 
 buildscript {
     repositories {
-        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -15,18 +14,15 @@ plugins {
 }
 
 repositories {
-        mavenCentral()
-        jcenter()
+    jcenter()
 }
 
 subprojects {
     repositories {
-        mavenCentral()
         jcenter()
     }
     buildscript {
         repositories {
-            mavenCentral()
             jcenter()
         }
         dependencies {


### PR DESCRIPTION
jcenter is a super set on top of maven central, so having both of those repositories is redundant, and the preferred one should be jcenter.

CheckList:

  * [x] Update API docs for the component.
  * [x] Update/Add demo to demonstrate new feature.
  * [x] Update test scripts for the feature.
  * [x] Add unit tests for the feature.

(checked, although not really relevant - not a feature nor bug...)