### PR TITLE
custom bugfix when native custom component  set visibility

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/WXImageView.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/WXImageView.java
@@ -192,18 +192,7 @@ public class WXImageView extends ImageView implements WXGestureObservable,
       }
     }
   }
-
-  @Override
-  protected void onVisibilityChanged(@NonNull View changedView, int visibility) {
-    super.onVisibilityChanged(changedView, visibility);
-    if(changedView == this){
-        if(visibility == View.VISIBLE){
-          autoRecoverImage();
-        }else{
-          autoReleaseImage();
-        }
-    }
-  }
+  
 
   @Override
   protected void onAttachedToWindow() {


### PR DESCRIPTION
onVisibilityChanged most sense right. but when native component custom set parent visibility, the method not paired on some platform, e.g when parent become invisible, changedView is this, visibility is invisible.