### PR TITLE
[WEEX-98][iOS]bug-fix addEvent lead to generate a new view while it as been recycled

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Events/WXComponent+Events.m
+++ b/ios/sdk/WeexSDK/Sources/Events/WXComponent+Events.m
@@ -154,6 +154,11 @@ if ([removeEventName isEqualToString:@#eventName]) {\
 
 - (void)_addEventOnMainThread:(NSString *)addEventName
 {
+    if (![self isViewLoaded]) {
+        //This action will be ignored While the view is loaded,
+        //then it will initEvent according to the records in _events
+        return;
+    }
     WX_ADD_EVENT(appear, addAppearEvent)
     WX_ADD_EVENT(disappear, addDisappearEvent)
     


### PR DESCRIPTION

  In most case , element in cell will be re-use for memory especially in very
long list, but if add event for this element, here will generate a new view for
this element,if it's nil due to a  getter method whether it is off-screen.

  For instance, image element in cell will re-use if it is disappear in vision area,
loaded again while it back to visual area. In this case , when it disappear, just
add event such as click, touch and so on , it will then create a new view,
and load image again, although it is off-screen.

  If the view is not loaded, so won't add gesture or call this view getter to create
any view until the view is loaded, then it will init events according to record in
component.

Bug: 98
