### PR TITLE
[WEEX-94][iOS] fix iOS 8 scrollview assign delegate crash

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
@@ -204,6 +204,7 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
 
 - (void)dealloc
 {
+    ((UIScrollView *)_view).delegate = nil;
     [self.stickyArray removeAllObjects];
     [self.listenerArray removeAllObjects];
     


### PR DESCRIPTION
   As iOS developers all knowns, assign property will not be set nil when
its object deallocated, and weak object will does, so we must set it to the 
nil value, in case of crash about messaging to zombie object. In iOS 8 and
the older iOS, the property of delegate of UIScrollView is assign, so we
must set it to nil manually when object deallocated. And in iOS 9 and later
iOS, apple change the delegate property of UIScrollView it to weak, so we
don't set it to nil value any more. For compatibility on iOS 8, here we must
set it to nil value.

Bug: 94