### PR TITLE
[WEEX-99][iOS] fix setViewport: sometimes doesn't work

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/module/WXMetaModule.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/module/WXMetaModule.java
@@ -39,7 +39,7 @@ public class WXMetaModule extends WXModule {
     public static final String WIDTH = "width";
     public static final String DEVICE_WIDTH = "device-width";
 
-    @JSMethod
+    @JSMethod(uiThread = false)
     public void setViewport(String param) {
         if (!TextUtils.isEmpty(param)) {
             try {

--- a/android/sdk/src/main/java/com/taobao/weex/ui/module/WXMetaModule.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/module/WXMetaModule.java
@@ -39,7 +39,7 @@ public class WXMetaModule extends WXModule {
     public static final String WIDTH = "width";
     public static final String DEVICE_WIDTH = "device-width";
 
-    @JSMethod(uiThread = false)
+    @JSMethod
     public void setViewport(String param) {
         if (!TextUtils.isEmpty(param)) {
             try {

--- a/ios/sdk/WeexSDK/Sources/Module/WXMetaModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXMetaModule.m
@@ -25,7 +25,7 @@
 
 @synthesize weexInstance;
 
-WX_EXPORT_METHOD(@selector(setViewport:))
+WX_EXPORT_METHOD_SYNC(@selector(setViewport:))
 
 - (void)setViewport:(NSDictionary *)viewportArguments
 {


### PR DESCRIPTION
[WEEX-99][iOS] fix setViewport: sometimes doesn't work.

The setViewport method in WXMetaModule is ASYN right now which makes weexInstance.viewportWidth setted after view created.

Bug:99