### PR TITLE
[WEEX-99][iOS] fix setViewport: sometimes doesn't work

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Module/WXMetaModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXMetaModule.m
@@ -25,7 +25,7 @@
 
 @synthesize weexInstance;
 
-WX_EXPORT_METHOD(@selector(setViewport:))
+WX_EXPORT_METHOD_SYNC(@selector(setViewport:))
 
 - (void)setViewport:(NSDictionary *)viewportArguments
 {


### PR DESCRIPTION
[WEEX-99][iOS] fix setViewport: sometimes doesn't work.

The setViewport method in WXMetaModule is ASYN right now which makes weexInstance.viewportWidth setted after view created.

Bug:99