### PR TITLE
[WEEX-99][Android] fix setViewport: sometimes doesn't work

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/module/WXMetaModule.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/module/WXMetaModule.java
@@ -39,7 +39,7 @@ public class WXMetaModule extends WXModule {
     public static final String WIDTH = "width";
     public static final String DEVICE_WIDTH = "device-width";
 
-    @JSMethod(uiThread = false)
+    @JSMethod
     public void setViewport(String param) {
         if (!TextUtils.isEmpty(param)) {
             try {


### PR DESCRIPTION
[WEEX-99][Android] fix setViewport: sometimes doesn't work.

The setViewport method in WXMetaModule is ASYN right now which makes weexInstance.viewportWidth setted after view created.

Bug:99