### PR TITLE
[jsfm] Support register and trigger component hooks

### DIFF
--- a/html5/runtime/bridge/CallbackManager.js
+++ b/html5/runtime/bridge/CallbackManager.js
@@ -19,6 +19,10 @@
 
 import { decodePrimitive } from './normalize'
 
+function getHookKey (componentId, type, hookName) {
+  return `${type}@${hookName}#${componentId}`
+}
+
 /**
  * For general callback management of a certain Weex instance.
  * Because function can not passed into native, so we create callback
@@ -31,6 +35,7 @@ export default class CallbackManager {
     this.instanceId = instanceId
     this.lastCallbackId = 0
     this.callbacks = {}
+    this.hooks = {}
   }
   add (callback) {
     this.lastCallbackId++
@@ -41,6 +46,31 @@ export default class CallbackManager {
     const callback = this.callbacks[callbackId]
     delete this.callbacks[callbackId]
     return callback
+  }
+  registerHook (componentId, type, hookName, hookFunction) {
+    // TODO: validate arguments
+    const key = getHookKey(componentId, type, hookName)
+    if (this.hooks[key]) {
+      console.warn(`[JS Framework] Override an existing component hook "${key}".`)
+    }
+    this.hooks[key] = hookFunction
+  }
+  triggerHook (componentId, type, hookName, options = {}) {
+    // TODO: validate arguments
+    const key = getHookKey(componentId, type, hookName)
+    const hookFunction = this.hooks[key]
+    if (typeof hookFunction === 'function') {
+      console.error(`[JS Framework] Invalid hook function type (${typeof hookFunction}) on "${key}".`)
+      return null
+    }
+    let result = null
+    try {
+      result = hookFunction.apply(null, options.args || [])
+    }
+    catch (e) {
+      console.error(`[JS Framework] Failed to execute the hook function on "${key}".`)
+    }
+    return result
   }
   consume (callbackId, data, ifKeepAlive) {
     const callback = this.callbacks[callbackId]
@@ -54,5 +84,6 @@ export default class CallbackManager {
   }
   close () {
     this.callbacks = {}
+    this.hooks = {}
   }
 }

--- a/html5/runtime/bridge/TaskCenter.js
+++ b/html5/runtime/bridge/TaskCenter.js
@@ -42,6 +42,14 @@ export class TaskCenter {
     return this.callbackManager.consume(callbackId, data, ifKeepAlive)
   }
 
+  registerHook (...args) {
+    return this.callbackManager.registerHook(...args)
+  }
+
+  triggerHook (...args) {
+    return this.callbackManager.triggerHook(...args)
+  }
+
   destroyCallback () {
     return this.callbackManager.close()
   }

--- a/html5/runtime/bridge/receiver.js
+++ b/html5/runtime/bridge/receiver.js
@@ -31,6 +31,21 @@ function callback (document, callbackId, data, ifKeepAlive) {
   return document.taskCenter.callback(callbackId, data, ifKeepAlive)
 }
 
+function componentHook (document, componentId, type, hook, options) {
+  if (!document || !document.taskCenter) {
+    console.error(`[JS Framework] Can't find "document" or "taskCenter".`)
+    return null
+  }
+  let result = null
+  try {
+    result = document.taskCenter.triggerHook(componentId, type, hook, options)
+  }
+  catch (e) {
+    console.error(`[JS Framework] Failed to trigger the "${type}@${hook}" hook on ${componentId}.`)
+  }
+  return result
+}
+
 /**
  * Accept calls from native (event or callback).
  *
@@ -47,6 +62,7 @@ export function receiveTasks (id, tasks) {
       switch (task.method) {
         case 'callback': return callback(document, ...task.args)
         case 'fireEvent': return fireEvent(document, ...task.args)
+        case 'componentHook': return componentHook(document, ...task.args)
       }
     })
   }


### PR DESCRIPTION
Support to receive the `componentHook` task via `callJS`, and expose the `registerHook` and `triggerHook` APIs in the task center.

This feature can be used to achieve the lifecycle hook within `<recycle-list>`. The design proposal can be found in https://github.com/Hanks10100/weex-native-directive/tree/master/component .

The front-end frameworks (Vue.js, Rax) rely on this feature to implement the virtual component.