### PR TITLE
[jsfm] Add a tracker for legacy ".we" framework

### DIFF
--- a/html5/runtime/api/init.js
+++ b/html5/runtime/api/init.js
@@ -22,6 +22,7 @@ import { receiveTasks } from '../bridge/receiver'
 import { registerModules } from './module'
 import { registerComponents } from './component'
 import { services, register, unregister } from './service'
+import { createTracker } from '../utils'
 import WeexInstance from './WeexInstance'
 
 let frameworks
@@ -99,6 +100,7 @@ function createInstance (id, code, config, data) {
   config.env = JSON.parse(JSON.stringify(global.WXEnvironment || {}))
 
   const weex = new WeexInstance(id, config)
+  const tracker = createTracker(weex)
   Object.freeze(weex)
 
   const runtimeEnv = {
@@ -117,6 +119,15 @@ function createInstance (id, code, config, data) {
   if (!framework) {
     return new Error(`invalid bundle type "${bundleType}".`)
   }
+  if (bundleType === 'Weex') {
+    console.error(`[JS Framework] COMPATIBILITY WARNING: `
+      + `Weex DSL 1.0 (.we) framework is no longer supported! `
+      + `It will be removed in the next version of WeexSDK, `
+      + `your page would be crash if you still using the ".we" framework. `
+      + `Please upgrade it to Vue.js or Rax.`)
+  }
+
+  tracker('bundleType', bundleType)
 
   // run create instance
   if (typeof framework.prepareInstanceContext === 'function') {

--- a/html5/runtime/utils.js
+++ b/html5/runtime/utils.js
@@ -52,3 +52,25 @@ export function base64ToBuffer (base64) {
   })
   return array.buffer
 }
+
+export function createTracker (weex, options = {}) {
+  if (!weex || typeof weex.requireModule !== 'function') {
+    console.error(`[JS Framework] Failed to create tracker!`)
+  }
+  return function WeexJSFrameworkTracker (type, value) {
+    if (type && value) {
+      const label = `jsfm.${type}.${value}`
+      try {
+        const userTrack = weex.requireModule('userTrack')
+        if (userTrack && userTrack.addPerfPoint) {
+          const message = Object.create(null)
+          message[label] = '4'
+          userTrack.addPerfPoint(message)
+        }
+      }
+      catch (err) {
+        console.error(`[JS Framework] Failed to trace "${label}"!`)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a tracker to collect the bundle type usage message. If the developer is still using the legacy ".we" framework, it'll print an error in console and record the bundle messages.

References: [WEEX-90: Remove The Legacy Weex DSL 1.0 (.we) Front-End Framework](https://issues.apache.org/jira/browse/WEEX-90)