### PR TITLE
[WEEX-105][iOS] bug-fix about setting nan frame crash

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXListComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXListComponent.m
@@ -58,6 +58,12 @@
     if (fabs(contentOffset.y) < 0.5) {
         contentOffset.y = 0;
     }
+    if (isnan(contentOffset.x)) {
+        contentOffset.x = 0;
+    }
+    if(isnan(contentOffset.y)) {
+        contentOffset.y = 0;
+    }
     
     [super setContentOffset:contentOffset];
 }

--- a/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
+++ b/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.m
@@ -166,10 +166,10 @@
     _cssNode->layout.should_update = false;
     _isLayoutDirty = NO;
     
-    CGRect newFrame = CGRectMake(WXRoundPixelValue(_cssNode->layout.position[CSS_LEFT]),
-                                 WXRoundPixelValue(_cssNode->layout.position[CSS_TOP]),
-                                 WXRoundPixelValue(_cssNode->layout.dimensions[CSS_WIDTH]),
-                                 WXRoundPixelValue(_cssNode->layout.dimensions[CSS_HEIGHT]));
+    CGRect newFrame = CGRectMake(isnan(WXRoundPixelValue(_cssNode->layout.position[CSS_LEFT]))?0:WXRoundPixelValue(_cssNode->layout.position[CSS_LEFT]),
+                                 isnan(WXRoundPixelValue(_cssNode->layout.position[CSS_TOP]))?0:WXRoundPixelValue(_cssNode->layout.position[CSS_TOP]),
+                                 isnan(WXRoundPixelValue(_cssNode->layout.dimensions[CSS_WIDTH]))?0:WXRoundPixelValue(_cssNode->layout.dimensions[CSS_WIDTH]),
+                                 isnan(WXRoundPixelValue(_cssNode->layout.dimensions[CSS_HEIGHT]))?0:WXRoundPixelValue(_cssNode->layout.dimensions[CSS_HEIGHT]));
     
     BOOL isFrameChanged = NO;
     if (!CGRectEqualToRect(newFrame, _calculatedFrame)) {


### PR DESCRIPTION
try to protect nan crash when set frame containing nan value.
Last Exception Backtrace:
```
0   CoreFoundation                  0x00000001830301c0 __exceptionPreprocess :124 (in CoreFoundation)
1   libobjc.A.dylib                 0x0000000181a6855c _objc_exception_throw :56 (in libobjc.A.dylib)
2   CoreFoundation                  0x0000000183030108 +[NSException raise:format:] :116 (in CoreFoundation)
3   QuartzCore                      0x0000000186335db8 CA::Layer::set_position(CA::Vec2 const&, bool) :152 (in QuartzCore)
4   QuartzCore                      0x0000000186335f2c -[CALayer setPosition:] :40 (in QuartzCore)
5   QuartzCore                      0x00000001863364c4 -[CALayer setFrame:] :448 (in QuartzCore)
6   UIKit                           0x0000000188e71e2c -[UIView(Geometry) setFrame:] :784 (in UIKit)
7   Taobao4iPhone                   0x0000000102d6ad4c _43-[WXComponent(Layout) _frameDidCalculated:]_block_invoke WXComponent+Layout.m:136
```
Last Exception Backtrace 2:
```
0   CoreFoundation                  0x0000000185b12fe0 __exceptionPreprocess :124 (in CoreFoundation)
1   libobjc.A.dylib                 0x0000000184574538 _objc_exception_throw :56 (in libobjc.A.dylib)
2   CoreFoundation                  0x0000000185b12f28 +[NSException raise:format:] :116 (in CoreFoundation)
3   QuartzCore                      0x0000000188e29798 CA::Layer::set_bounds(CA::Rect const&, bool) :204 (in QuartzCore)
4   QuartzCore                      0x0000000188e299e0 -[CALayer setBounds:] :100 (in QuartzCore)
5   UIKit                           0x000000018bc908c8 -[UIView(Geometry) setBounds:] :404 (in UIKit)
6   UIKit                           0x000000018bc9eacc -[UIScrollView setBounds:] :988 (in UIKit)
7   UIKit                           0x000000018bd271c8 -[UITableView setBounds:] :224 (in UIKit)
8   UIKit                           0x000000018bc62828 -[UIScrollView setContentOffset:] :400 (in UIKit)
9   UIKit                           0x000000018bd191dc -[UITableView setContentOffset:] :272 (in UIKit)
10  Taobao4iPhone                   0x0000000102d7b6e8 -[WXTableView setContentOffset:] WXListComponent.m:63 (in Taobao4iPhone)
11  UIKit                           0x000000018bde6d08 -[UIScrollView _updatePanGesture] :1988 (in UIKit)
12  UIKit                           0x000000018c2168d0 -[UIGestureRecognizerTarget _sendActionWithGestureRecognizer:] :64 (in UIKit)
13  UIKit                           0x000000018c21a104 _UIGestureRecognizerSendTargetActions :124 (in UIKit)
14  UIKit                           0x000000018bdd40b4 _UIGestureRecognizerSendActions :252 (in UIKit)
```
Bug: 105
