### PR TITLE
[WEEX-106][iOS] add instanceId to performance dict, that we can differentiate…

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Monitor/WXMonitor.m
+++ b/ios/sdk/WeexSDK/Sources/Monitor/WXMonitor.m
@@ -165,6 +165,8 @@ static WXThreadSafeMutableDictionary *globalPerformanceDict;
         commitDict[commitKey] = @([end integerValue] - [start integerValue]);
     }
     
+    commitDict[@"instanceId"] = [instance instanceId]?:@"";
+    
     id<WXAppMonitorProtocol> appMonitor = [WXHandlerFactory handlerForProtocol:@protocol(WXAppMonitorProtocol)];
     if (appMonitor && [appMonitor respondsToSelector:@selector(commitAppMonitorArgs:)]){
         [appMonitor commitAppMonitorArgs:commitDict];


### PR DESCRIPTION
add instanceId to performance dict, that we can differentiate instance exactly。

Then we can do something like this:
1. get instanceId when deal with performance
2. upload performance with instanceId