### PR TITLE
[WEEX-109][iOS] add scrollstart and scrollend event's interface for scroller

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
@@ -264,10 +264,10 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
     if ([eventName isEqualToString:@"scroll"]) {
         _scrollEvent = YES;
     }
-    if ([eventName isEqualToString:@"scrollStart"]) {
+    if ([eventName isEqualToString:@"scrollstart"]) {
         _scrollStartEvent = YES;
     }
-    if ([eventName isEqualToString:@"scrollEnd"]) {
+    if ([eventName isEqualToString:@"scrollend"]) {
         _scrollEndEvent = YES;
     }
 }
@@ -280,10 +280,10 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
     if ([eventName isEqualToString:@"scroll"]) {
         _scrollEvent = NO;
     }
-    if ([eventName isEqualToString:@"scrollStart"]) {
+    if ([eventName isEqualToString:@"scrollstart"]) {
         _scrollStartEvent = NO;
     }
-    if ([eventName isEqualToString:@"scrollEnd"]) {
+    if ([eventName isEqualToString:@"scrollend"]) {
         _scrollEndEvent = NO;
     }
 }

--- a/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
@@ -488,6 +488,10 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
 }
 
 #pragma mark UIScrollViewDelegate
+- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
+{
+    [self fireEvent:@"scrollstart" params:nil domChanges:nil];
+}
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
@@ -569,6 +573,8 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
     }
     
     [scrollView setContentInset:inset];
+    [self fireEvent:@"scrollend" params:nil domChanges:nil];
+
 }
 
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate


### PR DESCRIPTION
[WEEX-109] [iOS]  add scrollstart and scrollend event's interface for scroller
Just use fireEvent to make UIScrollViewDelegate exposed to the front users.
Now can use  'scrollstart' and 'scrollend' to get scroller's status.
https://issues.apache.org/jira/browse/WEEX-109
http://dotwe.org/vue/96421f059fb7481faa4af86adb813efa
http://dotwe.org/vue/30fce705bf5c8a0763a95367c9b8dcfe