### PR TITLE
[WEEX-119][iOS] disable tableview estimation row or section height.

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXListComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXListComponent.m
@@ -155,6 +155,10 @@
     _tableView.delegate = self;
     _tableView.dataSource = self;
     _tableView.userInteractionEnabled = YES;
+    
+    _tableView.estimatedRowHeight = 0;
+    _tableView.estimatedSectionFooterHeight = 0;
+    _tableView.estimatedSectionHeaderHeight = 0;
 }
 
 - (void)viewWillUnload


### PR DESCRIPTION
  according to  https://stackoverflow.com/questions/46445661/ios-11-uitableview-behaviour-changed/46447370#46447370
  https://forums.developer.apple.com/message/245686  this estimation action will make tableview edit abnormal, crash sometimes
  so disable it from iOS 11.

Bug: 119