### PR TITLE
[WEEX-101][iOS] specify voice-over navigation order is column or vertical

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXComponent_internal.h
+++ b/ios/sdk/WeexSDK/Sources/Component/WXComponent_internal.h
@@ -70,6 +70,7 @@ typedef id (^WXDataBindingBlock)(NSDictionary *data, BOOL *needUpdate);
     NSString * _ariaHidden; // accessibilityElementsHidden
     NSString * _accessible; // accessible
     NSString * _accessibilityHintContent; // hint for the action
+    NSString * _groupAccessibilityChildren; // voice-over navigation order
     NSString * _testId;// just for auto-test
     
     BOOL _accessibilityMagicTapEvent;

--- a/ios/sdk/WeexSDK/Sources/Model/WXComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Model/WXComponent.m
@@ -126,6 +126,9 @@
         if(attributes[@"accessibilityHint"]) {
             _accessibilityHintContent = [WXConvert NSString:attributes[@"accessibilityHint"]];
         }
+        if (attributes[@"groupAccessibilityChildren"]) {
+            _groupAccessibilityChildren = [WXConvert NSString:attributes[@"groupAccessibilityChildren"]];
+        }
         
         if (attributes[@"testId"]) {
             _testId = [WXConvert NSString:attributes[@"testId"]];
@@ -365,6 +368,9 @@
         
         if (_ariaHidden) {
             [_view setAccessibilityElementsHidden:[WXConvert BOOL:_ariaHidden]];
+        }
+        if (_groupAccessibilityChildren) {
+            [_view setShouldGroupAccessibilityChildren:[WXConvert BOOL:_groupAccessibilityChildren]];
         }
         
         [self _initEvents:self.events];
@@ -735,6 +741,12 @@
         _accessibilityHintContent = [WXConvert NSString:attributes[@"accessibilityHint"]];
         [self.view setAccessibilityHint:_accessibilityHintContent];
     }
+    
+    if (attributes[@"groupAccessibilityChildren"]) {
+        _groupAccessibilityChildren = [WXConvert NSString:attributes[@"groupAccessibilityChildren"]];
+        [self.view setShouldGroupAccessibilityChildren:[WXConvert BOOL:_groupAccessibilityChildren]];
+    }
+
     
     if (attributes[@"testId"]) {
         [self.view setAccessibilityIdentifier:[WXConvert NSString:attributes[@"testId"]]];


### PR DESCRIPTION
Consider an app that shows items in vertical columns. Normally, voiceOver would navigate through
these items in horizontal rows. Setting the value of this property to YES on the parent element of the
items in the vertical columns causes VoiceOver to respect the app’s grouping and navigate them.Andthe default of this property is NO.

Bug:101