### PR TITLE
[WEEX-122][iOS]bugfix round float pixel lead to the lack of pixel

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
+++ b/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
@@ -224,6 +224,11 @@ typedef enum : NSUInteger {
     if ([configCenter respondsToSelector:@selector(configForKey:defaultValue:isDefault:)]) {
         BOOL useCoreText = [[configCenter configForKey:@"iOS_weex_ext_config.text_render_useCoreText" defaultValue:@YES isDefault:NULL] boolValue];
         [WXTextComponent setRenderUsingCoreText:useCoreText];
+        
+        //handler pixel round
+        BOOL shouldRoudPixel = [[configCenter configForKey:@"iOS_weex_ext_config.utilityShouldRoundPixel" defaultValue:@(NO) isDefault:NULL] boolValue];
+        [WXUtility setShouldRoudPixel:shouldRoudPixel];
+        
         id sliderConfig =  [configCenter configForKey:@"iOS_weex_ext_config.slider_class_name" defaultValue:@"WXCycleSliderComponent" isDefault:NULL];
         if(sliderConfig){
             NSString *sliderClassName = [WXConvert NSString:sliderConfig];

--- a/ios/sdk/WeexSDK/Sources/Utility/WXUtility.h
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXUtility.h
@@ -460,4 +460,7 @@ BOOL WXFloatGreaterThanWithPrecision(CGFloat a,CGFloat b,double precision);
  */
 + (NSData *_Nonnull)base64DictToData:(NSDictionary *_Nullable)base64Dict;
 
+
++ (void)setShouldRoudPixel:(BOOL)shouldRoundPixel;
+
 @end

--- a/ios/sdk/WeexSDK/Sources/Utility/WXUtility.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXUtility.m
@@ -41,6 +41,8 @@
 #define KEY_PASSWORD  @"com.taobao.Weex.123456"
 #define KEY_USERNAME_PASSWORD  @"com.taobao.Weex.weex123456"
 
+static BOOL utilityShouldRoundPixel = NO;
+
 void WXPerformBlockOnMainThread(void (^ _Nonnull block)())
 {
     if (!block) return;
@@ -117,20 +119,29 @@ CGFloat WXPixelScale(CGFloat value, CGFloat scaleFactor)
 
 CGFloat WXRoundPixelValue(CGFloat value)
 {
-    CGFloat scale = WXScreenScale();
-    return round(value * scale) / scale;
+    if (utilityShouldRoundPixel) {
+        CGFloat scale = WXScreenScale();
+        return round(value * scale) / scale;
+    }
+    return value;
 }
 
 CGFloat WXCeilPixelValue(CGFloat value)
 {
-    CGFloat scale = WXScreenScale();
-    return ceil(value * scale) / scale;
+    if (utilityShouldRoundPixel) {
+        CGFloat scale = WXScreenScale();
+        return ceil(value * scale) / scale;
+    }
+    return value;
 }
 
 CGFloat WXFloorPixelValue(CGFloat value)
 {
-    CGFloat scale = WXScreenScale();
-    return floor(value * scale) / scale;
+    if (utilityShouldRoundPixel) {
+        CGFloat scale = WXScreenScale();
+        return floor(value * scale) / scale;
+    }
+    return value;
 }
 
 @implementation WXUtility
@@ -154,6 +165,14 @@ CGFloat WXFloorPixelValue(CGFloat value)
     block();
 }
 
++ (void)setShouldRoudPixel:(BOOL)shouldRoundPixel
+{
+    utilityShouldRoundPixel = shouldRoundPixel;
+}
++ (BOOL)shouldRoudPixel
+{
+    return utilityShouldRoundPixel;
+}
 
 + (NSDictionary *)getEnvironment
 {


### PR DESCRIPTION
 this action will let iOS decide whether it should draw float pixel.

Bug:122

here are some cases about this problem

http://dotwe.org/vue/b0a242260e1df1b93964834b43bd25f7
http://dotwe.org/vue/32c8940df1673c2642abfd39f0ce9421

and the screenshot, the right one has been correct.

![image](https://user-images.githubusercontent.com/11631084/32841771-da8239bc-c9e0-11e7-8893-dee2138a98b0.png)

![image](https://user-images.githubusercontent.com/11631084/32841942-6ebd310e-c9e1-11e7-89a2-65174808778c.png)
