### PR TITLE
[WEEX-102][iOS]bugfix appear event will fire wrongly while the view has not been loaded

### DIFF
--- a/ios/playground/WeexDemo/WXConfigCenterDefaultImpl.m
+++ b/ios/playground/WeexDemo/WXConfigCenterDefaultImpl.m
@@ -39,7 +39,7 @@
     if ([keys[0] isEqualToString:@"iOS_weex_prerender_config"] && [keys[1] isEqualToString:@"max_cache_num"]){
         return @2;
     }
-    return nil;
+    return defaultValue;
 }
 
 @end


### PR DESCRIPTION
if the view has not been loaded or has not been added to its scroller view, it should not be
notified appear event, because it cannot scroll to appear area as the scrollview scroll.

Bug:102

you can try this case http://dotwe.org/vue/26c9717b1c60304668899b996ac8a9ac