### PR TITLE
[WEEX-124][iOS]Transform's parse problem about translate

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXTransform.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTransform.m
@@ -312,7 +312,6 @@
             }
         }
     }
-    
     _originX = [WXLength lengthWithFloat:originX type:typeX];
     _originY = [WXLength lengthWithFloat:originY type:typeY];
 }
@@ -368,14 +367,12 @@
 - (void)parseTranslatey:(NSArray *)value
 {
     WXLength *translateY;
-    if (value.count > 1) {
-        double y = [value[0] doubleValue];
-        if ([value[0] hasSuffix:@"%"]) {
-            translateY = [WXLength lengthWithFloat:y type:WXLengthTypePercent];
-        } else {
-            y = WXPixelScale(y, self.weexInstance.pixelScaleFactor);
-            translateY = [WXLength lengthWithFloat:y type:WXLengthTypeFixed];
-        }
+    double y = [value[0] doubleValue];
+    if ([value[0] hasSuffix:@"%"]) {
+        translateY = [WXLength lengthWithFloat:y type:WXLengthTypePercent];
+    } else {
+        y = WXPixelScale(y, self.weexInstance.pixelScaleFactor);
+        translateY = [WXLength lengthWithFloat:y type:WXLengthTypeFixed];
     }
     _translateY = translateY;
 }

--- a/ios/sdk/WeexSDK/Sources/Component/WXTransform.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTransform.m
@@ -348,6 +348,12 @@
 
 - (void)parseTranslate:(NSArray *)value
 {
+    [self parseTranslatex:@[value[0]]];
+    [self parseTranslatey:@[value[1]]];
+}
+
+- (void)parseTranslatex:(NSArray *)value
+{
     WXLength *translateX;
     double x = [value[0] doubleValue];
     if ([value[0] hasSuffix:@"%"]) {
@@ -356,30 +362,22 @@
         x = WXPixelScale(x, self.weexInstance.pixelScaleFactor);
         translateX = [WXLength lengthWithFloat:x type:WXLengthTypeFixed];
     }
+    _translateX = translateX;
+}
 
+- (void)parseTranslatey:(NSArray *)value
+{
     WXLength *translateY;
     if (value.count > 1) {
-        double y = [value[1] doubleValue];
-        if ([value[1] hasSuffix:@"%"]) {
+        double y = [value[0] doubleValue];
+        if ([value[0] hasSuffix:@"%"]) {
             translateY = [WXLength lengthWithFloat:y type:WXLengthTypePercent];
         } else {
             y = WXPixelScale(y, self.weexInstance.pixelScaleFactor);
             translateY = [WXLength lengthWithFloat:y type:WXLengthTypeFixed];
         }
     }
-    
-    _translateX = translateX;
     _translateY = translateY;
-}
-
-- (void)parseTranslatex:(NSArray *)value
-{
-    [self parseTranslate:@[value[0], @"0"]];
-}
-
-- (void)parseTranslatey:(NSArray *)value
-{
-    [self parseTranslate:@[@"0", value[0]]];
 }
 
 - (void)parseScale:(NSArray *)value

--- a/ios/sdk/WeexSDK/Sources/Module/WXTransition.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXTransition.m
@@ -243,21 +243,20 @@
                 info.perValue = @([info.toValue floatValue] - [info.fromValue floatValue]);
                 [_propertyArray addObject:info];
             }
-            
             if (wxTransform.translateX && [wxTransform.translateX floatValue] !=[oldTransform.translateX floatValue]) {
                 WXTransitionInfo *info = [WXTransitionInfo new];
                 info.propertyName = @"transform.translation.x";
-                info.fromValue = @([oldTransform.translateX valueForMaximum:_targetComponent.view.bounds.size.width]);
-                info.toValue = @([wxTransform.translateX valueForMaximum:_targetComponent.view.bounds.size.width]);
-                info.perValue = @([info.toValue floatValue] - [info.fromValue floatValue]);
+                info.fromValue = @([oldTransform.translateX floatValue]);
+                info.toValue = @([wxTransform.translateX floatValue]);
+                info.perValue = @([wxTransform.translateX floatValue] - [oldTransform.translateX floatValue]);
                 [_propertyArray addObject:info];
             }
             if (wxTransform.translateY && [wxTransform.translateY floatValue] !=[oldTransform.translateY floatValue]) {
                 WXTransitionInfo *info = [WXTransitionInfo new];
                 info.propertyName = @"transform.translation.y";
-                info.fromValue = @([oldTransform.translateY valueForMaximum:_targetComponent.view.bounds.size.height]);
-                info.toValue = @([wxTransform.translateY valueForMaximum:_targetComponent.view.bounds.size.height]);
-                info.perValue = @([info.toValue floatValue] - [info.fromValue floatValue]);
+                info.fromValue = @([oldTransform.translateY floatValue]);
+                info.toValue = @([wxTransform.translateY floatValue]);
+                info.perValue = @([wxTransform.translateY floatValue] - [oldTransform.translateY floatValue]);
                 [_propertyArray addObject:info];
             }
             _targetComponent->_transform = wxTransform;


### PR DESCRIPTION
We found that in AnimationModule's transform do not support examples such as ' translateX(10px) translateY(20px)',and we fix this bug about transform.
translateX(10px):http://dotwe.org/vue/cb4c0ac40a9705dc5662e918f3dfc7ec
translateY(10px):http://dotwe.org/vue/cefaca9588abe1342e77262899d911c1
translateX(100px) translateY(200px):http://dotwe.org/vue/e0a4f0bcb26a73fc8d46d18b80186d5c
translate(200px,200px):http://dotwe.org/vue/7c7de13d2a3ac31d9085d941bef2c88a