### PR TITLE
[WEEX-131][ios]URL property in error event of web component may not be the real URL, fix it.

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.m
@@ -200,9 +200,15 @@ WX_EXPORT_METHOD(@selector(goForward))
         NSMutableDictionary *data = [self baseInfo];
         [data setObject:[error localizedDescription] forKey:@"errorMsg"];
         [data setObject:[NSString stringWithFormat:@"%ld", (long)error.code] forKey:@"errorCode"];
-        if(error.userInfo && ![error.userInfo[NSURLErrorFailingURLStringErrorKey] hasPrefix:@"http"]){
-            return;
-        }
+		
+		NSString * urlString = error.userInfo[NSURLErrorFailingURLStringErrorKey];
+		if (urlString) {
+			// webview.request may not be the real error URL, must get from error.userInfo
+			[data setObject:urlString forKey:@"url"];
+			if (![urlString hasPrefix:@"http"]) {
+				return;
+			}
+		}
         [self fireEvent:@"error" params:data];
     }
 }

--- a/test/pages/components/web-event.vue
+++ b/test/pages/components/web-event.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <panel title = 'web-event' :padding-body='0'>
-      <div style='flex-direction:row'> 
-        <web ref='web-ref' class="mr-base web" :src = "src"  @pagestart = "pagestartEvt" @pagefinish = "pagefinishEvt" @error = "errorEvt"></web> 
+      <div style='flex-direction:row'>
+        <web ref='web-ref' class="mr-base web" :src = "src"  @pagestart = "pagestartEvt" @pagefinish = "pagefinishEvt" @error = "errorEvt"></web>
       </div>
       <div style='flex-direction:row'>
         <button class='mr-base' type="info" size="middle" value="reload" @click.native="reload"></button>
@@ -18,11 +18,11 @@
     <wxc-desc>
       <text class='desc'>
 测试点：
-  * 
+  *
 
 测试方式：
-  * 
-  * 
+  *
+  *
       </text>
     </wxc-desc>
   </div>
@@ -33,7 +33,7 @@
 
   module.exports = {
     data : {
-      src:'http://www.error.com',
+      src:'https://error.a-never-exists-site-for-testcase-in-weex.com',
       txtStart:'',
       txtFinish:'',
       txtError:''

--- a/test/scripts/components/web-event.test.js
+++ b/test/scripts/components/web-event.test.js
@@ -28,7 +28,7 @@ describe('weex '+goal+' test @ignore-android', function () {
       .waitForElementByName(goal, maxW, 2000)
       .waitForElementByName('txtStart:https://www.baidu.com/', maxW, 2000)
       .waitForElementByName('txtFinish:https://www.baidu.com/', maxW, 2000)
-      .waitForElementByName('txtError:http://www.error.com/', maxW, 2000)
+      .waitForElementByName('txtError:https://error.a-never-exists-site-for-testcase-in-weex.com/', maxW, 2000)
       .waitForElementByName('reload', maxW, 2000)
       .click().sleep(500)
       .waitForElementByName('txtFinish:https://www.baidu.com/', maxW, 2000)


### PR DESCRIPTION
[WEEX-131][ios]URL property in error event of web component may not be the real URL, fix it.

In error callback, webview.request may return the previous loaded web page URL, use error.userInfo to get the real error URL.

And http://www.error.com exists now, change it to another URL.