### PR TITLE
* [doc] doc example: delete <text> props “lines”

### DIFF
--- a/doc/source/cn/references/components/text.md
+++ b/doc/source/cn/references/components/text.md
@@ -97,10 +97,10 @@ version: 2.1
 <template>
   <div class="wrapper">
     <div class="panel">
-      <text class="text" lines="3">Weex 是一套简单易用的跨平台开发方案，能以 Web 的开发体验构建高性能、可扩展的原生应用。Vue 是一个轻量并且功能强大的渐进式前端框架。</text>
+      <text class="text">Weex 是一套简单易用的跨平台开发方案，能以 Web 的开发体验构建高性能、可扩展的原生应用。Vue 是一个轻量并且功能强大的渐进式前端框架。</text>
     </div>
     <div class="panel">
-      <text class="text" lines="3">Weex is an cross-platform development solution that builds high-performance, scalable native applications with a Web development experience. Vue is a lightweight and powerful progressive front-end framework. </text>
+      <text class="text">Weex is an cross-platform development solution that builds high-performance, scalable native applications with a Web development experience. Vue is a lightweight and powerful progressive front-end framework. </text>
     </div>
   </div>
 </template>

--- a/doc/source/examples/text.md
+++ b/doc/source/examples/text.md
@@ -9,10 +9,10 @@ web_bundle_url: ../js/examples/text.web.js
 <template>
   <div class="wrapper">
     <div class="panel">
-      <text class="text" lines="3">Weex 是一套简单易用的跨平台开发方案，能以 Web 的开发体验构建高性能、可扩展的原生应用。Vue 是一个轻量并且功能强大的渐进式前端框架。</text>
+      <text class="text">Weex 是一套简单易用的跨平台开发方案，能以 Web 的开发体验构建高性能、可扩展的原生应用。Vue 是一个轻量并且功能强大的渐进式前端框架。</text>
     </div>
     <div class="panel">
-      <text class="text" lines="3">Weex is an cross-platform development solution that builds high-performance, scalable native applications with a Web development experience. Vue is a lightweight and powerful progressive front-end framework. </text>
+      <text class="text">Weex is an cross-platform development solution that builds high-performance, scalable native applications with a Web development experience. Vue is a lightweight and powerful progressive front-end framework. </text>
     </div>
   </div>
 </template>

--- a/doc/source/references/components/text.md
+++ b/doc/source/references/components/text.md
@@ -94,10 +94,10 @@ support `ttf` and `woff` font format to custom your text, call [addRule](../modu
 <template>
   <div class="wrapper">
     <div class="panel">
-      <text class="text" lines="3">Weex 是一套简单易用的跨平台开发方案，能以 Web 的开发体验构建高性能、可扩展的原生应用。Vue 是一个轻量并且功能强大的渐进式前端框架。</text>
+      <text class="text">Weex 是一套简单易用的跨平台开发方案，能以 Web 的开发体验构建高性能、可扩展的原生应用。Vue 是一个轻量并且功能强大的渐进式前端框架。</text>
     </div>
     <div class="panel">
-      <text class="text" lines="3">Weex is an cross-platform development solution that builds high-performance, scalable native applications with a Web development experience. Vue is a lightweight and powerful progressive front-end framework. </text>
+      <text class="text">Weex is an cross-platform development solution that builds high-performance, scalable native applications with a Web development experience. Vue is a lightweight and powerful progressive front-end framework. </text>
     </div>
   </div>
 </template>


### PR DESCRIPTION
`<text>` component props “lines” is invalid, so I delete “lines=3” in all doc files.

weex playgroud demo（which proved what I said）: http://dotwe.org/vue/5ac8c3970d049c1c0b41c4ef9a103963

