### PR TITLE
* [doc] doc references: update weex.config.bundleUrl's description

### DIFF
--- a/doc/source/cn/references/weex-variable.md
+++ b/doc/source/cn/references/weex-variable.md
@@ -14,7 +14,7 @@ has_chapter_content: true
 
 该变量包含了当前 Weex 页面的所有环境信息，包括不仅限于：
 
-* `bundleUrl: string`: JS bundle 的 URL。
+* `bundleUrl: string`: JS bundle 的 URL，和页面的 URL 一致。
 * `env: Object`: 环境对象。
     * `weexVersion: string`: Weex sdk 版本。
     * `appName: string`: 应用名字。

--- a/doc/source/references/weex-variable.md
+++ b/doc/source/references/weex-variable.md
@@ -13,7 +13,7 @@ Each Weex page has a separate weex variable, which exists in the JS context. The
 
 This variable contains all the environment information for the current Weex page, including not only:       
 
-+ `BundleUrl`: string: The URL of the JS bundle.
++ `BundleUrl`: string: The URL of the JS bundle, the same as URL of the page.
 + `Env: Object`: environment object.
 + `WeexVersion: string`: Weex sdk version.
 + `AppName: string`: application name.


### PR DESCRIPTION
weex.config.bundleUrl's description is confused. 

I thinked it is jsUrl without queryString ago.I spent a half of day, finally know bundleUrl is  the same as URL of the page.

so I come here to change doc for people can quickly get the answer in future.