### PR TITLE
[WEEX-109][iOS] bugfix with scrollstart and scrollend event's and doc update

### DIFF
--- a/doc/source/cn/references/common-style.md
+++ b/doc/source/cn/references/common-style.md
@@ -344,7 +344,7 @@ transform 属性向元素应用 2D 转换。该属性允许我们对元素进行
 
 
 
-## transition <span class="api-version">v0.16.0+</span>
+## transition <span class="api-version">v0.17.0+</span>
 
 现在您可以在CSS中使用transition属性来提升您应用的交互性与视觉感受，transition中包括布局动画，即LayoutAnimation，现在布局产生变化的同时也能使用transition带来的流畅动画。transition允许CSS的属性值在一定的时间区间内平滑地过渡。
 

--- a/doc/source/cn/references/components/scroller.md
+++ b/doc/source/cn/references/components/scroller.md
@@ -72,6 +72,10 @@ version: 2.1
     - `x {number}`: x轴上的偏移量
     - `y {number}`: y轴上的偏移量
 
+- `scrollstart` <sup class="wx-v">v0.17+</sup>：列表刚开始发生滚动的时候会触发该事件，可以在此执行滚动开始的逻辑。
+
+- `scrollend` <sup class="wx-v">v0.17+</sup>：列表结束滚动的时候会触发该事件，可以在此执行滚动结束的逻辑。
+
 - 通用事件
 
   支持所有通用事件：

--- a/doc/source/references/common-style.md
+++ b/doc/source/references/common-style.md
@@ -231,7 +231,7 @@ Currently supported format:
 </style>
 ```
 
-## transition <span class="api-version">v0.16.0+</span>
+## transition <span class="api-version">v0.17.0+</span>
 
 Now you can use the transition attribute in CSS to enhance the interactivity and visual experience of your application. The transition includes the layout animation, that is, LayoutAnimation, which now changes the layout and uses the fluent animation of the transition. Transition allows the CSS attribute values to transition smoothly over a certain time interval.
 

--- a/doc/source/references/components/scroller.md
+++ b/doc/source/references/components/scroller.md
@@ -48,15 +48,23 @@ common styles: check out [common styles for components](../common-style.html)
 
 ## Events
 
-`loadmore`  used with loadmoreoffset attribute. if the view has less than loadmoreoffset to scroll down, the onloadmore event will be triggered.
+- `loadmore`  used with loadmoreoffset attribute. if the view has less than loadmoreoffset to scroll down, the onloadmore event will be triggered.
+- `scroll`  <sup class="wx-v">0.12+</sup> used with offset-accuracy attribute. This event is fired when the list scrolls. The current contentOffset value is given in this event callback.  See details in [scroll event demo](http://dotwe.org/vue/9ef0e52bacaa20182a693f2187d851aa).
+  - contentSize {Object}`：The content size of the list
+    - `width {number}`: List content width
+    - `height {number}`: List content height
+  - `contentOffset {Object}`: Offset size of the list
+    - `x {number}`: Offset on x-axis
+    - `y {number}`: Offset on y-axis
+- `scrollstart` <sup class="wx-v">v0.17+</sup>：This event is triggered when the list starts to scroll, where you can start the logic of the start of the scrolling.
+- `scrollend` <sup class="wx-v">v0.17+</sup>：This event is triggered when the list has finished scrolling, where you can execute the logic that the scroll ends.
+- common events: check out the [common events](../common-event.html)
+  - `click`
+  - `longpress`
+  - `appear`
+  - `disappear`
 
-`scroll`  <sup class="wx-v">0.12+</sup> used with offset-accuracy attribute. This event is fired when the list scrolls. The current contentOffset value is given in this event callback.  See details in [scroll event demo](http://dotwe.org/vue/9ef0e52bacaa20182a693f2187d851aa).
-
-common events: check out the [common events](../common-event.html)
-
-* support onclick event. Check out [common events](../common-event.html)
-* support onappear / ondisappear event. Check out [common events](../common-event.html)
-
+## event.html)
 
 
 ## Restrictions

--- a/doc/source/references/components/scroller.md
+++ b/doc/source/references/components/scroller.md
@@ -50,7 +50,7 @@ common styles: check out [common styles for components](../common-style.html)
 
 - `loadmore`  used with loadmoreoffset attribute. if the view has less than loadmoreoffset to scroll down, the onloadmore event will be triggered.
 - `scroll`  <sup class="wx-v">0.12+</sup> used with offset-accuracy attribute. This event is fired when the list scrolls. The current contentOffset value is given in this event callback.  See details in [scroll event demo](http://dotwe.org/vue/9ef0e52bacaa20182a693f2187d851aa).
-  - contentSize {Object}`：The content size of the list
+  - `contentSize {Object}`：The content size of the list
     - `width {number}`: List content width
     - `height {number}`: List content height
   - `contentOffset {Object}`: Offset size of the list

--- a/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
@@ -634,6 +634,7 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
     }
     if (!decelerate) {
         _isScrolling = NO;
+        [self performSelector:@selector(scrollViewDidEndDecelerating:) withObject:nil afterDelay:0.1];
     }
 }
 


### PR DESCRIPTION
refix some bug about slow drag scoller with no animation to get 'scrollend' event's bug.

And in this pr, we fix scrollend event can not be called's bug, also, add document about scroller's scrollstart and scollend.
test case: http://dotwe.org/vue/ba8045f24bf6e1265bb51e94b5ef418c

Besides, fix transition doc version in this pr.