### PR TITLE
[WEEX-156][web] bugfix: the unit wx doesn't work correctly

### DIFF
--- a/html5/render/vue/README.md
+++ b/html5/render/vue/README.md
@@ -202,6 +202,10 @@ vue: {
 
 * fix indicator position in one page slider.
 
+#### 0.12.26
+
+* fix unit wx, which is a straight px value not to adapt to screens.
+
 ## component -> dom map
 
 | component | dom element | children | note |

--- a/html5/render/vue/utils/style.js
+++ b/html5/render/vue/utils/style.js
@@ -90,10 +90,10 @@ export function normalizeUnitsNum (val: string): string {
 }
 
 function getUnitScaleMap () {
-  const { scale, dpr } = getViewportInfo()
+  const { scale } = getViewportInfo()
   return {
     px: scale,
-    wx: scale * dpr
+    wx: 1 // use px straight, not adaptable to screens.
   }
 }
 

--- a/html5/test/render/vue/modules/modal.js
+++ b/html5/test/render/vue/modules/modal.js
@@ -55,16 +55,17 @@ describe('modal module', function () {
       expect(toast.push).to.be.a('function')
       expect(toast.show).to.be.a('function')
     })
-    it('should toast mount on document when push method is called', function () {
+    it('should toast mount on document when push method is called', function (done) {
       const TOAST_WIN_CLASS_NAME = '.weex-toast'
       let $Toast = null
-      const clock = sinon.useFakeTimers()
       toast.push(config.message, config.duration)
       $Toast = document.querySelector(TOAST_WIN_CLASS_NAME)
       expect($Toast.innerText, 'should contain Test message').to.be.equal(config.message)
       expect(nodeListToArray($Toast.classList), 'should include hide class').to.include('hide')
-      clock.tick(config.duration * 1000)
-      expect(nodeListToArray($Toast.classList), 'should remove hide class').to.not.include('hide')
+      setTimeout(function () {
+        expect(nodeListToArray($Toast.classList), 'should remove hide class').to.not.include('hide')
+        done()
+      }, config.duration * 1000)
     })
     it('call show method while toast queue length < 1', function () {
       const TOAST_WIN_CLASS_NAME = '.weex-toast'

--- a/html5/test/render/vue/utils/style.js
+++ b/html5/test/render/vue/utils/style.js
@@ -40,8 +40,7 @@ describe('style', function () {
   // const rect = document.documentElement.getBoundingClientRect()
   // const info = {}
   const {
-    scale,
-    dpr
+    scale
   } = init()
   it('should support using 0.5px to paint 1px width border', () => {
     expect(supportHairlines()).to.be.false
@@ -56,7 +55,7 @@ describe('style', function () {
   it('should normalize units numbers', () => {
     expect(normalizeUnitsNum('100px')).to.equal(100 * scale + 'px')
     expect(normalizeUnitsNum('100')).to.equal(100 * scale + 'px')
-    expect(normalizeUnitsNum('100wx')).to.equal(100 * scale * dpr + 'px')
+    expect(normalizeUnitsNum('100wx')).to.equal('100px')
     expect(normalizeUnitsNum('20wm')).to.equal('')
   })
   it('should normalize number style vals', () => {
@@ -67,7 +66,7 @@ describe('style', function () {
     expect(normalizeString('width', '100%')).to.equal('100%')
     expect(normalizeString('transform', 'translate3d(10px, 10px, 10px)')).to.equal(`translate3d(${10 * scale}px, ${10 * scale}px, ${10 * scale}px)`)
     expect(normalizeString('border-bottom', '4px solid #112233')).to.equal(`${4 * scale}px solid #112233`)
-    expect(normalizeString('border-left', '4wx dotted red')).to.equal(`${4 * scale * dpr}px dotted red`)
+    expect(normalizeString('border-left', '4wx dotted red')).to.equal(`4px dotted red`)
   })
   it('should normalize style object', () => {
     const style = {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "subversion": {
     "browser": "0.5.0",
     "framework": "0.22.4",
-    "vue-render": "0.12.25",
+    "vue-render": "0.12.26",
     "transformer": ">=0.1.5 <0.5"
   },
   "description": "A framework for building Mobile cross-platform UI",

--- a/packages/weex-vue-render/README.md
+++ b/packages/weex-vue-render/README.md
@@ -202,6 +202,10 @@ vue: {
 
 * fix indicator position in one page slider.
 
+#### 0.12.26
+
+* fix unit wx, which is a straight px value not to adapt to screens.
+
 ## component -> dom map
 
 | component | dom element | children | note |

--- a/packages/weex-vue-render/package.json
+++ b/packages/weex-vue-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weex-vue-render",
-  "version": "0.12.25",
+  "version": "0.12.26",
   "description": "Weex built-in components for Vue 2.x.",
   "license": "Apache-2.0",
   "main": "dist/index.common.js",


### PR DESCRIPTION
> [WEEX-156][web] bugfix: the unit wx doesn't work correctly

Since the wx unit was designed to match the native unit px, so the '1wx'
should be the same long in any devices or any screens. It doesn't adapt
to screens by multiply a ratio which is weex.config.env.scale. Just
keep them in px forms and be their original values.