### PR TITLE
* [jsfm] support fireEventSync and send component hooks

### DIFF
--- a/html5/runtime/bridge/CallbackManager.js
+++ b/html5/runtime/bridge/CallbackManager.js
@@ -32,7 +32,7 @@ function getHookKey (componentId, type, hookName) {
  */
 export default class CallbackManager {
   constructor (instanceId) {
-    this.instanceId = instanceId
+    this.instanceId = String(instanceId)
     this.lastCallbackId = 0
     this.callbacks = {}
     this.hooks = {}
@@ -59,7 +59,7 @@ export default class CallbackManager {
     // TODO: validate arguments
     const key = getHookKey(componentId, type, hookName)
     const hookFunction = this.hooks[key]
-    if (typeof hookFunction === 'function') {
+    if (typeof hookFunction !== 'function') {
       console.error(`[JS Framework] Invalid hook function type (${typeof hookFunction}) on "${key}".`)
       return null
     }

--- a/html5/runtime/bridge/TaskCenter.js
+++ b/html5/runtime/bridge/TaskCenter.js
@@ -29,7 +29,7 @@ export class TaskCenter {
   constructor (id, sendTasks) {
     Object.defineProperty(this, 'instanceId', {
       enumerable: true,
-      value: id
+      value: String(id)
     })
     Object.defineProperty(this, 'callbackManager', {
       enumerable: true,
@@ -48,6 +48,10 @@ export class TaskCenter {
 
   triggerHook (...args) {
     return this.callbackManager.triggerHook(...args)
+  }
+
+  updateData (componentId, newData) {
+    this.callModule('dom', 'updateComponentData', [newData])
   }
 
   destroyCallback () {

--- a/html5/runtime/bridge/receiver.js
+++ b/html5/runtime/bridge/receiver.js
@@ -55,12 +55,14 @@ function componentHook (document, componentId, type, hook, options) {
 export function receiveTasks (id, tasks) {
   const document = getDoc(id)
   if (!document) {
-    return new Error(`Invalid instance id "${id}", failed the receive tasks.`)
+    return new Error(`[JS Framework] Failed to receiveTasks, `
+      + `instance (${id}) is not available.`)
   }
   if (Array.isArray(tasks)) {
     return tasks.map(task => {
       switch (task.method) {
         case 'callback': return callback(document, ...task.args)
+        case 'fireEventSync':
         case 'fireEvent': return fireEvent(document, ...task.args)
         case 'componentHook': return componentHook(document, ...task.args)
       }

--- a/html5/runtime/vdom/Document.js
+++ b/html5/runtime/vdom/Document.js
@@ -162,7 +162,7 @@ export default class Document {
       return
     }
     event = event || {}
-    event.type = type
+    event.type = event.type || type
     event.target = el
     event.currentTarget = el
     event.timestamp = Date.now()


### PR DESCRIPTION
Support `fireEventSync` and send `updateComponentData` signal to native render engines.

These features can be used to achieve gesture events and `<recycle-list>`.