### PR TITLE
[WEEX-162][android] When Cell Position Changed , item.getCellPositionINScollable() not right

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/list/BasicListComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/list/BasicListComponent.java
@@ -28,6 +28,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.util.ArrayMap;
 import android.support.v4.view.MotionEventCompat;
+import android.support.v4.view.ViewCompat;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -1166,13 +1167,13 @@ public abstract class BasicListComponent<T extends ViewGroup & ListComponentView
         continue;
       }
 
-      boolean outOfVisibleRange = item.getCellPositionINScollable() < firstVisible || item.getCellPositionINScollable() > lastVisible;
 
       View view = component.getHostView();
       if (view == null) {
         continue;
       }
 
+      boolean outOfVisibleRange = !ViewCompat.isAttachedToWindow(view);
       boolean visible = (!outOfVisibleRange) && item.isViewVisible(true);
 
       int result = item.setAppearStatus(visible);


### PR DESCRIPTION
When Cell Position Changed , outOfVisibleRange not accurate, item.getCellPositionINScollable() get wrong position use instead.
boolean outOfVisibleRange = !ViewCompat.isAttachedToWindow(view);
