### PR TITLE
[WEEX-168] [iOS] Animation needLayout may show incorrect

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Module/WXTransition.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXTransition.m
@@ -141,9 +141,10 @@
     if (styles.count == 0) {
         return;
     }
-    NSString *singleProperty = styles.allKeys[0];
-    if ([propertyNames containsString:singleProperty]) {
-        [self _dealTransitionWithProperty:singleProperty styles:styles];
+    for (NSString * name  in styles.allKeys) {
+        if ([propertyNames containsString:name]) {
+            [self _dealTransitionWithProperty:name styles:styles];
+        }
     }
 }
 


### PR DESCRIPTION
Fix bug when animation's needLayout is true with two animation together.

By fixing the array problem when styles is not single.
