### PR TITLE
[WEEX-183][jsfm] support append tree on root element

### DIFF
--- a/html5/runtime/vdom/operation.js
+++ b/html5/runtime/vdom/operation.js
@@ -122,15 +122,9 @@ export function appendBody (doc, node, before) {
 
 function sendBody (doc, node) {
   const body = node.toJSON()
-  const children = body.children
-  delete body.children
-  let result = doc.taskCenter.send('dom', { action: 'createBody' }, [body])
-  if (children) {
-    children.forEach(child => {
-      result = doc.taskCenter.send('dom', { action: 'addElement' }, [body.ref, child, -1])
-    })
+  if (doc && doc.taskCenter && typeof doc.taskCenter.send === 'function') {
+    doc.taskCenter.send('dom', { action: 'createBody' }, [body])
   }
-  return result
 }
 
 /**

--- a/html5/test/unit/default/vm/vm.js
+++ b/html5/test/unit/default/vm/vm.js
@@ -245,20 +245,16 @@ describe('generate virtual dom for a single vm', () => {
       attr: {
         append: 'tree'
       },
+      children: [{
+        ref: spy.firstCall.args[2].children[0].ref,
+        type: 'text',
+        attr: {
+          value: '<some text content>'
+        },
+        style: {}
+      }],
       style: {}
     })
-    expect(spy.secondCall.args[0]).to.be.equal('test')
-    expect(spy.secondCall.args[1]).to.be.equal('addElement')
-    expect(spy.secondCall.args[2]).to.be.equal('_root')
-    expect(spy.secondCall.args[3]).to.deep.equal({
-      ref: spy.secondCall.args[3].ref,
-      type: 'text',
-      attr: {
-        value: '<some text content>'
-      },
-      style: {}
-    })
-    expect(spy.secondCall.args[4]).to.be.equal(-1)
 
     expect(vm._app).equal(app)
     const el = doc.body


### PR DESCRIPTION
See this example: http://dotwe.org/vue/c479b4f8b2e7243efe1cfed2f442e35a

Even there is an append="tree" on the root element, js framework will send two render directives to native. JS Framework does it on purpose to ensure the performance of sending the first render directive (`createBody`). I think this feature is no longer needed.