### PR TITLE
fix no return value problem when validation is failed.

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Bridge/WXBridgeMethod.m
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXBridgeMethod.m
@@ -103,7 +103,8 @@
     }
     
     NSArray *arguments = _arguments;
-    if (signature.numberOfArguments - 2 < arguments.count) {
+    // when target is an instance of NSError's subclass, checking is meaningless.
+    if ((signature.numberOfArguments - 2 < arguments.count) && ![target isKindOfClass:[NSError class]]) {
         NSString *errorMessage = [NSString stringWithFormat:@"%@, the parameters in calling method [%@] and registered method [%@] are not consistent！", target, _methodName, NSStringFromSelector(selector)];
         WX_MONITOR_FAIL(WXMTJSBridge, WX_ERR_INVOKE_NATIVE, errorMessage);
         return nil;

--- a/ios/sdk/WeexSDK/Sources/Bridge/WXBridgeMethod.m
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXBridgeMethod.m
@@ -103,8 +103,7 @@
     }
     
     NSArray *arguments = _arguments;
-    // when target is an instance of NSError's subclass, checking is meaningless.
-    if ((signature.numberOfArguments - 2 < arguments.count) && ![target isKindOfClass:[NSError class]]) {
+    if (signature.numberOfArguments - 2 < arguments.count) {
         NSString *errorMessage = [NSString stringWithFormat:@"%@, the parameters in calling method [%@] and registered method [%@] are not consistent！", target, _methodName, NSStringFromSelector(selector)];
         WX_MONITOR_FAIL(WXMTJSBridge, WX_ERR_INVOKE_NATIVE, errorMessage);
         return nil;

--- a/ios/sdk/WeexSDK/Sources/Bridge/WXModuleMethod.m
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXModuleMethod.m
@@ -28,6 +28,8 @@
 #import "WXHandlerFactory.h"
 #import "WXValidateProtocol.h"
 
+#define ARGUMENTS @"arguments"
+
 @implementation WXModuleMethod
 
 - (instancetype)initWithModuleName:(NSString *)moduleName
@@ -59,7 +61,10 @@
                 WXLogError(@"%@", errorMessage);
                 WX_MONITOR_FAIL(WXMTJSBridge, WX_ERR_INVOKE_NATIVE, errorMessage);
                 if ([result.error respondsToSelector:@selector(userInfo)]) {
-                    // NSError instance won't work as target instance.
+                    // In order to pass the argument count check in -[WXBridgeMethod invocationWithTarget:selector:]
+                    if ([self respondsToSelector:NSSelectorFromString(ARGUMENTS)]) {
+                        [self setValue:nil forKey:ARGUMENTS];
+                    }
                     NSInvocation *invocation = [self invocationWithTarget:result.error selector:@selector(userInfo)];
                     [invocation invoke];
                     return invocation;

--- a/ios/sdk/WeexSDK/Sources/Bridge/WXModuleMethod.m
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXModuleMethod.m
@@ -28,8 +28,6 @@
 #import "WXHandlerFactory.h"
 #import "WXValidateProtocol.h"
 
-#define ARGUMENTS @"arguments"
-
 @implementation WXModuleMethod
 
 - (instancetype)initWithModuleName:(NSString *)moduleName
@@ -61,9 +59,9 @@
                 WXLogError(@"%@", errorMessage);
                 WX_MONITOR_FAIL(WXMTJSBridge, WX_ERR_INVOKE_NATIVE, errorMessage);
                 if ([result.error respondsToSelector:@selector(userInfo)]) {
-                    // In order to pass the argument count check in -[WXBridgeMethod invocationWithTarget:selector:]
-                    if ([self respondsToSelector:NSSelectorFromString(ARGUMENTS)]) {
-                        [self setValue:nil forKey:ARGUMENTS];
+                    // update the arguments when validate failed, so update the arguments for invoking -[NSError userInfo].
+                    if ([self respondsToSelector:NSSelectorFromString(@"arguments")]) {
+                        [self setValue:nil forKey:@"arguments"];
                     }
                     NSInvocation *invocation = [self invocationWithTarget:result.error selector:@selector(userInfo)];
                     [invocation invoke];

--- a/ios/sdk/WeexSDK/Sources/Bridge/WXModuleMethod.m
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXModuleMethod.m
@@ -59,6 +59,7 @@
                 WXLogError(@"%@", errorMessage);
                 WX_MONITOR_FAIL(WXMTJSBridge, WX_ERR_INVOKE_NATIVE, errorMessage);
                 if ([result.error respondsToSelector:@selector(userInfo)]) {
+                    // NSError instance won't work as target instance.
                     NSInvocation *invocation = [self invocationWithTarget:result.error selector:@selector(userInfo)];
                     [invocation invoke];
                     return invocation;


### PR DESCRIPTION
Fix the problem that getting `nil` return value when weex api validation is failed beofre invoking. 