### PR TITLE
[WEEX-190][iOS] Performance statistics improvement for weex rendering

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Bridge/WXBridgeContext.m
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXBridgeContext.m
@@ -523,6 +523,10 @@ _Pragma("clang diagnostic pop") \
             [WXAppConfiguration setJSFrameworkVersion:[frameworkVersion toString]];
         }
         
+        if (script) {
+             [WXAppConfiguration setJSFrameworkLibSize:[script lengthOfBytesUsingEncoding:NSUTF8StringEncoding]];
+        }
+        
         //execute methods which has been stored in methodQueue temporarily.
         for (NSDictionary *method in _methodQueue) {
             [self callJSMethod:method[@"method"] args:method[@"args"]];

--- a/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.m
@@ -668,7 +668,7 @@ static css_node_t * rootNodeGetChild(void *context, int i)
     [self _addUITask:^{
         UIView *rootView = instance.rootView;
         
-        WX_MONITOR_INSTANCE_PERF_END(WXPTFirstScreenRender, instance);
+        //WX_MONITOR_INSTANCE_PERF_END(WXPTFirstScreenRender, instance);
         WX_MONITOR_INSTANCE_PERF_END(WXPTAllRender, instance);
         WX_MONITOR_SUCCESS(WXMTJSBridge);
         WX_MONITOR_SUCCESS(WXMTNativeRender);

--- a/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
+++ b/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
@@ -46,6 +46,7 @@
 #import "WXJSExceptionProtocol.h"
 #import "WXTracingManager.h"
 #import "WXExceptionUtils.h"
+#import "WXMonitor.h"
 
 NSString *const bundleUrlOptionKey = @"bundleUrl";
 
@@ -68,6 +69,7 @@ typedef enum : NSUInteger {
     WXComponentManager *_componentManager;
     WXRootView *_rootView;
     WXThreadSafeMutableDictionary *_moduleEventObservers;
+    BOOL  _performanceCommit;
 }
 
 - (void)dealloc
@@ -100,6 +102,7 @@ typedef enum : NSUInteger {
         _attrConfigs = [NSMutableDictionary new];
         _moduleEventObservers = [WXThreadSafeMutableDictionary new];
         _trackComponent = NO;
+        _performanceCommit = NO;
        
         [self addObservers];
     }
@@ -405,6 +408,11 @@ typedef enum : NSUInteger {
     if (!self.instanceId) {
         WXLogError(@"Fail to find instance！");
         return;
+    }
+    
+    if (!_performanceCommit && state == WeexInstanceDisappear) {
+        WX_MONITOR_INSTANCE_PERF_COMMIT(self);
+        _performanceCommit = YES;
     }
     
     NSMutableDictionary *data = [NSMutableDictionary dictionary];

--- a/ios/sdk/WeexSDK/Sources/Monitor/WXMonitor.h
+++ b/ios/sdk/WeexSDK/Sources/Monitor/WXMonitor.h
@@ -63,6 +63,7 @@ NSError *error = [NSError errorWithDomain:WX_ERROR_DOMAIN \
 #define WX_MONITOR_INSTANCE_PERF_END(tag, instance) [WXMonitor performancePoint:tag didEndWithInstance:instance];
 #define WX_MONITOR_PERF_SET(tag, value, instance) [WXMonitor performancePoint:tag didSetValue:value withInstance:instance];
 #define WX_MONITOR_INSTANCE_PERF_IS_RECORDED(tag, instance) [WXMonitor performancePoint:tag isRecordedWithInstance:instance]
+#define WX_MONITOR_INSTANCE_PERF_COMMIT(instance) [WXMonitor performanceFinish:instance]
 
 @interface WXMonitor : NSObject
 
@@ -70,6 +71,7 @@ NSError *error = [NSError errorWithDomain:WX_ERROR_DOMAIN \
 + (void)performancePoint:(WXPerformanceTag)tag didEndWithInstance:(WXSDKInstance *)instance;
 + (void)performancePoint:(WXPerformanceTag)tag didSetValue:(double)value withInstance:(WXSDKInstance *)instance;
 + (BOOL)performancePoint:(WXPerformanceTag)tag isRecordedWithInstance:(WXSDKInstance *)instance;
++ (void)performanceFinish:(WXSDKInstance *)instance;
 
 + (void)monitoringPointDidSuccess:(WXMonitorTag)tag onPage:(NSString *)pageName;
 + (void)monitoringPoint:(WXMonitorTag)tag didFailWithError:(NSError *)error onPage:(NSString *)pageName;

--- a/ios/sdk/WeexSDK/Sources/Monitor/WXMonitor.m
+++ b/ios/sdk/WeexSDK/Sources/Monitor/WXMonitor.m
@@ -62,9 +62,9 @@ static WXThreadSafeMutableDictionary *globalPerformanceDict;
     
     dict[kEndKey] = @(CACurrentMediaTime() * 1000);
     
-    if (tag == WXPTAllRender) {
-        [self performanceFinish:instance];
-    }
+//    if (tag == WXPTAllRender) {
+//        [self performanceFinish:instance];
+//    }
 }
 
 + (void)performancePoint:(WXPerformanceTag)tag didSetValue:(double)value withInstance:(WXSDKInstance *)instance
@@ -92,19 +92,31 @@ static WXThreadSafeMutableDictionary *globalPerformanceDict;
 
 + (void)performanceFinish:(WXSDKInstance *)instance
 {
-    NSMutableDictionary *commitDict = [NSMutableDictionary dictionaryWithCapacity:WXPTEnd+4];
+    NSMutableDictionary *commitDict = [NSMutableDictionary dictionary];
     
     commitDict[BIZTYPE] = instance.bizType ?: @"";
     commitDict[PAGENAME] = instance.pageName ?: @"";
     
     commitDict[WXSDKVERSION] = WX_SDK_VERSION;
     commitDict[JSLIBVERSION] = [WXAppConfiguration JSFrameworkVersion];
+    commitDict[JSLIBSIZE] = [NSNumber numberWithUnsignedInteger:[WXAppConfiguration JSFrameworkLibSize]];
+    
     if (instance.userInfo[@"weex_bundlejs_connectionType"]) {
         commitDict[@"connectionType"] = instance.userInfo[@"weex_bundlejs_connectionType"];
     }
+    
     if (instance.userInfo[@"weex_bundlejs_requestType"]) {
         commitDict[@"requestType"] = instance.userInfo[@"weex_bundlejs_requestType"];
     }
+    
+    if (instance.userInfo[@"weex_bundlejs_networkType"]) {
+        commitDict[NETWORKTYPE] = instance.userInfo[@"weex_bundlejs_networkType"];
+    }
+    
+    if (instance.userInfo[@"weex_bundlejs_cacheType"]) {
+        commitDict[CACHETYPE] = instance.userInfo[@"weex_bundlejs_cacheType"];
+    }
+    
     if (instance.userInfo[CACHEPROCESSTIME]) {
         commitDict[CACHEPROCESSTIME] = instance.userInfo[CACHEPROCESSTIME];
     }
@@ -120,7 +132,7 @@ static WXThreadSafeMutableDictionary *globalPerformanceDict;
         }
     }
     WXPerformBlockOnComponentThread(^{
-        commitDict[@"componentCount"] = @([instance numberOfComponents]);
+        commitDict[COMPONENTCOUNT] = @([instance numberOfComponents]);
         WXPerformBlockOnMainThread(^{
             [self commitPerformanceWithDict:commitDict instance:instance];
         });
@@ -166,6 +178,21 @@ static WXThreadSafeMutableDictionary *globalPerformanceDict;
     }
     
     commitDict[@"instanceId"] = [instance instanceId]?:@"";
+    
+    //new performance point
+    if (!commitDict[SCREENRENDERTIME] && commitDict[TOTALTIME]) {
+        commitDict[SCREENRENDERTIME] = commitDict[TOTALTIME];
+    }
+    
+    commitDict[CALLCREATEINSTANCETIME] = commitDict[COMMUNICATETIME];
+    commitDict[COMMUNICATETOTALTIME] = commitDict[TOTALTIME];
+    
+    if (commitDict[SCREENRENDERTIME]) {
+        commitDict[FSRENDERTIME] = commitDict[SCREENRENDERTIME];
+    }
+    else {
+        commitDict[FSRENDERTIME] = @"-1";
+    }
     
     id<WXAppMonitorProtocol> appMonitor = [WXHandlerFactory handlerForProtocol:@protocol(WXAppMonitorProtocol)];
     if (appMonitor && [appMonitor respondsToSelector:@selector(commitAppMonitorArgs:)]){

--- a/ios/sdk/WeexSDK/Sources/Protocol/WXAppMonitorProtocol.h
+++ b/ios/sdk/WeexSDK/Sources/Protocol/WXAppMonitorProtocol.h
@@ -23,8 +23,11 @@
 #define PAGENAME            @"pageName"
 #define WXSDKVERSION        @"WXSDKVersion"
 #define JSLIBVERSION        @"JSLibVersion"
+#define JSLIBSIZE           @"JSLibSize"
 #define WXREQUESTTYPE       @"requestType"
 #define WXCONNECTIONTYPE    @"connectionType"
+#define NETWORKTYPE         @"networkType"
+#define CACHETYPE           @"cacheType"
 #define WXCUSTOMMONITORINFO @"customMonitorInfo"
 
 #define SDKINITTIME         @"SDKInitTime"
@@ -36,6 +39,11 @@
 #define SCREENRENDERTIME    @"screenRenderTime"
 #define TOTALTIME           @"totalTime"
 #define FIRSETSCREENJSFEXECUTETIME  @"firstScreenJSFExecuteTime"
+
+#define CALLCREATEINSTANCETIME  @"callCreateInstanceTime"
+#define COMMUNICATETOTALTIME    @"communicateTotalTime"
+#define FSRENDERTIME    @"fsRenderTime"
+#define COMPONENTCOUNT      @"componentCount"
 
 #define CACHEPROCESSTIME    @"cacheProcessTime"
 #define CACHERATIO          @"cacheRatio"

--- a/ios/sdk/WeexSDK/Sources/Protocol/WXConfigCenterProtocol.h
+++ b/ios/sdk/WeexSDK/Sources/Protocol/WXConfigCenterProtocol.h
@@ -17,4 +17,11 @@
  */
 - (id)configForKey:(NSString*)key defaultValue:(id)defaultValue isDefault:(BOOL*)isDefault;
 
+/**
+ get group config from config center handler
+ @param group the groupName for config
+*/
+
+- (id)configForGroup:(NSString*)group;
+
 @end

--- a/ios/sdk/WeexSDK/Sources/Utility/WXAppConfiguration.h
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXAppConfiguration.h
@@ -51,6 +51,11 @@
 + (NSString *)JSFrameworkVersion;
 + (void)setJSFrameworkVersion:(NSString *)JSFrameworkVersion;
 
+/**
+ + * @abstract JSFrameworkLibSize
+ + */
++ (NSUInteger)JSFrameworkLibSize;
++ (void)setJSFrameworkLibSize:(NSUInteger)JSFrameworkLibSize;
 
 /*
  *  @abstract customizeProtocolClasses

--- a/ios/sdk/WeexSDK/Sources/Utility/WXAppConfiguration.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXAppConfiguration.m
@@ -26,6 +26,7 @@
 @property (nonatomic, strong) NSString * appVersion;
 @property (nonatomic, strong) NSString * externalUA;
 @property (nonatomic, strong) NSString * JSFrameworkVersion;
+@property (nonatomic, assign) NSUInteger JSFrameworkLibSize;
 @property (nonatomic, strong) NSArray  * customizeProtocolClasses;
 @end
 
@@ -89,6 +90,16 @@
 + (void)setJSFrameworkVersion:(NSString *)JSFrameworkVersion
 {
     [WXAppConfiguration sharedConfiguration].JSFrameworkVersion = JSFrameworkVersion;
+}
+
++ (NSUInteger)JSFrameworkLibSize
+{
+    return [WXAppConfiguration sharedConfiguration].JSFrameworkLibSize;
+}
+
++ (void)setJSFrameworkLibSize:(NSUInteger)JSFrameworkLibSize
+{
+    [WXAppConfiguration sharedConfiguration].JSFrameworkLibSize = JSFrameworkLibSize;
 }
 
 + (NSArray*)customizeProtocolClasses{


### PR DESCRIPTION
In previous versions, there were some problems about the statistics of some key points, such as first screen rendering time and so on. Previously, when the operation of createFininshed was completed, we would record this point named FisrtScreenRenderTime, but this does not apply to the other situation when the rootView is only backgroundView. So，we want to add some new rules to make statistics more accurate.