### PR TITLE
#import <coreText/CoreText.h>   ==>   #import <CoreText/CoreText.h>

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Utility/WXUtility.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXUtility.m
@@ -33,7 +33,7 @@
 #import <UIKit/UIScreen.h>
 #import <Security/Security.h>
 #import <CommonCrypto/CommonCrypto.h>
-#import <coreText/CoreText.h>
+#import <CoreText/CoreText.h>
 #import "WXAppMonitorProtocol.h"
 
 #import "WXTextComponent.h"


### PR DESCRIPTION
In iOS SDK WXUtility.m file, the #import <coreText/CoreText.h> header file  written error