### PR TITLE
fix api 21 PaintDrawable Crash

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/utils/ImageDrawable.java
+++ b/android/sdk/src/main/java/com/taobao/weex/utils/ImageDrawable.java
@@ -21,12 +21,16 @@ package com.taobao.weex.utils;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapShader;
+import android.graphics.Canvas;
 import android.graphics.Matrix;
+import android.graphics.Paint;
 import android.graphics.RectF;
 import android.graphics.Shader;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.PaintDrawable;
+import android.graphics.drawable.shapes.Shape;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.widget.ImageView;
@@ -121,6 +125,15 @@ public class ImageDrawable extends PaintDrawable {
   public void setCornerRadii(float[] radii) {
     this.radii = radii;
     super.setCornerRadii(radii);
+  }
+
+  @Override
+  protected void onDraw(Shape shape, Canvas canvas, Paint paint) {
+    if (Build.VERSION.SDK_INT == Build.VERSION_CODES.LOLLIPOP) {
+      // fix api 21 PaintDrawable crash
+      paint.setAntiAlias(false);
+    }
+    super.onDraw(shape, canvas, paint);
   }
 
   public


### PR DESCRIPTION
PaintDrawable will crash on Api 21

crash stack:

SIGSEGV(SEGV_MAPERR):
#00 pc 000b0a4e /system/vendor/lib/egl/libGLESv2_adreno.so [armeabi-v7a::98aa079c3b61e1d8483bc6915a4ea80f]
#1 pc 000b12b3 /system/vendor/lib/egl/libGLESv2_adreno.so (oxili_tile_texture+282) [armeabi-v7a::98aa079c3b61e1d8483bc6915a4ea80f]
#2 pc 00087d9b /system/vendor/lib/egl/libGLESv2_adreno.so [armeabi-v7a::98aa079c3b61e1d8483bc6915a4ea80f]
#3 pc 00089b31 /system/vendor/lib/egl/libGLESv2_adreno.so (rb_texture_update_hw_subimage+4220) [armeabi-v7a::98aa079c3b61e1d8483bc6915a4ea80f]
#4 pc 0008ad35 /system/vendor/lib/egl/libGLESv2_adreno.so (rb_texture_loadimage+218) [armeabi-v7a::98aa079c3b61e1d8483bc6915a4ea80f]
#5 pc 00065dab /system/vendor/lib/egl/libGLESv2_adreno.so (TexImageLoad+234) [armeabi-v7a::98aa079c3b61e1d8483bc6915a4ea80f]
#6 pc 00066157 /system/vendor/lib/egl/libGLESv2_adreno.so (core_glTexImage2D+230) [armeabi-v7a::98aa079c3b61e1d8483bc6915a4ea80f]
#7 pc 00044391 /system/vendor/lib/egl/libGLESv2_adreno.so (glTexImage2D+50) [armeabi-v7a::98aa079c3b61e1d8483bc6915a4ea80f]
#8 pc 00038dc7 /system/lib/libhwui.so [armeabi-v7a::6020227c8682c7c307281ce48eb729d9]
#9 pc 0003944f /system/lib/libhwui.so [armeabi-v7a::6020227c8682c7c307281ce48eb729d9]
#10 pc 00039629 /system/lib/libhwui.so [armeabi-v7a::6020227c8682c7c307281ce48eb729d9]
#11 pc 00039693 /system/lib/libhwui.so [armeabi-v7a::6020227c8682c7c307281ce48eb729d9]
#12 pc 0003495b /system/lib/libhwui.so [armeabi-v7a::6020227c8682c7c307281ce48eb729d9]
#13 pc 00034aa9 /system/lib/libhwui.so [armeabi-v7a::6020227c8682c7c307281ce48eb729d9]
#14 pc 000350f3 /system/lib/libhwui.so [armeabi-v7a::6020227c8682c7c307281ce48eb729d9]
#15 pc 000280a3 /system/lib/libhwui.so [armeabi-v7a::6020227c8682c7c307281ce48eb729d9]
#16 pc 0002873b /system/lib/libhwui.so [armeabi-v7a::6020227c8682c7c307281ce48eb729d9]
#17 pc 0001d105 /system/lib/libhwui.so [armeabi-v7a::6020227c8682c7c307281ce48eb729d9]
#18 pc 0001b609 /system/lib/libhwui.so [armeabi-v7a::6020227c8682c7c307281ce48eb729d9]
#19 pc 0001b1d3 /system/lib/libhwui.so [armeabi-v7a::6020227c8682c7c307281ce48eb729d9]
#20 pc 0002a677 /system/lib/libhwui.so [armeabi-v7a::6020227c8682c7c307281ce48eb729d9]
#21 pc 0003a295 /system/lib/libhwui.so [armeabi-v7a::6020227c8682c7c307281ce48eb729d9]
#22 pc 0003b1a1 /system/lib/libhwui.so [armeabi-v7a::6020227c8682c7c307281ce48eb729d9]
#23 pc 0003cc9f /system/lib/libhwui.so (_ZN7android10uirenderer12renderthread12RenderThread10threadLoopEv+66) [armeabi-v7a::6020227c8682c7c307281ce48eb729d9]
#24 pc 0000ef55 /system/lib/libutils.so (_ZN7android6Thread11_threadLoopEPv+112) [armeabi-v7a::811cebf104cff63eacd6d977257b90fa]
#25 pc 0005a3ad /system/lib/libandroid_runtime.so (_ZN7android14AndroidRuntime15javaThreadShellEPv+72) [armeabi-v7a::159e1a4d880205218eff8fcd5e2ab8c2]
#26 pc 0000eac5 /system/lib/libutils.so [armeabi-v7a::811cebf104cff63eacd6d977257b90fa]
#27 pc 000137a3 /system/lib/libc.so (_ZL15__pthread_startPv+30) [armeabi-v7a::30577c4046d655391344f729791da864]
#28 pc 00011883 /system/lib/libc.so (__start_thread+6) [armeabi-v7a::30577c4046d655391344f729791da864]

when close hardware layer， crash stack change to ：
SIGSEGV(SEGV_MAPERR):
#00 pc 00197f78 /system/lib/libskia.so (_Z31S32_opaque_D32_nofilter_DX_neonRK17SkBitmapProcStatePKjiPj+143) [armeabi-v7a::fa6bef525f3435afbefe01e62dc3a290]
#1 pc 000b2f8f /system/lib/libskia.so (_ZN18SkBitmapProcShader23BitmapProcShaderContext9shadeSpanEiiPji+134) [armeabi-v7a::fa6bef525f3435afbefe01e62dc3a290]
#2 pc 000bca31 /system/lib/libskia.so (_ZN23SkARGB32_Shader_Blitter5blitVEiiih+526) [armeabi-v7a::fa6bef525f3435afbefe01e62dc3a290]
#3 pc 000b93fd /system/lib/libskia.so (_ZN9SkBlitter12blitAntiRectEiiiihh+28) [armeabi-v7a::fa6bef525f3435afbefe01e62dc3a290]
#4 pc 000ec6f3 /system/lib/libskia.so (_ZN12SuperBlitter8blitRectEiiii+226) [armeabi-v7a::fa6bef525f3435afbefe01e62dc3a290]
#5 pc 000eeaad /system/lib/libskia.so [armeabi-v7a::fa6bef525f3435afbefe01e62dc3a290]
#6 pc 000eefcb /system/lib/libskia.so (_Z12sk_fill_pathRK6SkPathPK7SkIRectP9SkBlitteriiiRK8SkRegion+294) [armeabi-v7a::fa6bef525f3435afbefe01e62dc3a290]
#7 pc 000ecb07 /system/lib/libskia.so (_ZN6SkScan12AntiFillPathERK6SkPathRK8SkRegionP9SkBlitterb+790) [armeabi-v7a::fa6bef525f3435afbefe01e62dc3a290]
#8 pc 000ecbe5 /system/lib/libskia.so (_ZN6SkScan12AntiFillPathERK6SkPathRK12SkRasterClipP9SkBlitter+32) [armeabi-v7a::fa6bef525f3435afbefe01e62dc3a290]
#9 pc 000c75cb /system/lib/libskia.so (_ZNK6SkDraw8drawPathERK6SkPathRK7SkPaintPK8SkMatrixbb+502) [armeabi-v7a::fa6bef525f3435afbefe01e62dc3a290]
#10 pc 000c1315 /system/lib/libskia.so (_ZN8SkCanvas8drawPathERK6SkPathRK7SkPaint+260) [armeabi-v7a::fa6bef525f3435afbefe01e62dc3a290]
#11 pc 0008eef7 /system/lib/libandroid_runtime.so (_ZN7android10SkiaCanvas8drawPathERK6SkPathRK7SkPaint+8) [armeabi-v7a::159e1a4d880205218eff8fcd5e2ab8c2]
#12 pc 00084b79 /system/lib/libandroid_runtime.so [armeabi-v7a::159e1a4d880205218eff8fcd5e2ab8c2]
#13 pc 000b0d97 /data/dalvik-cache/arm/system@framework@boot.oat [armeabi::31ad7c6b6fcc4c281410db7b971b660f]
java:
java.lang.Thread.parkFor(Thread.java:1220)
sun.misc.Unsafe.park(Unsafe.java:299)
java.util.concurrent.locks.LockSupport.park(LockSupport.java:157)
java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2016)
java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:410)
java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1035)
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1097)
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
java.lang.Thread.run(Thread.java:818)
java pending exception:
[Native crash above happened with a java pending exception as following]
java.lang.StackOverflowError: stack size 8MB
android.graphics.Canvas.drawPath(Canvas.java:1217)
android.graphics.drawable.shapes.RoundRectShape.draw(RoundRectShape.java:79)
android.graphics.drawable.ShapeDrawable.onDraw(ShapeDrawable.java:220)
android.graphics.drawable.ShapeDrawable.draw(ShapeDrawable.java:247)
android.widget.ImageView.onDraw(ImageView.java:1148)
com.taobao.weex.ui.view.WXImageView.onDraw(WXImageView.java:203)
android.view.View.draw(View.java:15128)
android.view.View.draw(View.java:15036)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.view.ViewGroup.dispatchDraw(ViewGroup.java:3199)
com.taobao.weex.ui.view.WXFrameLayout.dispatchDraw(WXFrameLayout.java:109)
android.view.View.draw(View.java:15031)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.view.ViewGroup.dispatchDraw(ViewGroup.java:3199)
com.taobao.weex.ui.view.WXFrameLayout.dispatchDraw(WXFrameLayout.java:109)
android.view.View.draw(View.java:15031)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.view.ViewGroup.dispatchDraw(ViewGroup.java:3199)
com.taobao.weex.ui.view.WXFrameLayout.dispatchDraw(WXFrameLayout.java:109)
android.view.View.draw(View.java:15131)
android.widget.FrameLayout.draw(FrameLayout.java:592)
android.view.View.draw(View.java:15036)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.view.ViewGroup.dispatchDraw(ViewGroup.java:3199)
com.taobao.weex.ui.view.WXFrameLayout.dispatchDraw(WXFrameLayout.java:109)
android.view.View.draw(View.java:15131)
android.widget.FrameLayout.draw(FrameLayout.java:592)
android.view.View.draw(View.java:15036)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.support.v7.widget.RecyclerView.drawChild(RecyclerView.java:4477)
android.view.ViewGroup.dispatchDraw(ViewGroup.java:3199)
android.view.View.draw(View.java:15131)
android.support.v7.widget.RecyclerView.draw(RecyclerView.java:3869)
android.view.View.draw(View.java:15036)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.view.ViewGroup.dispatchDraw(ViewGroup.java:3199)
android.view.View.draw(View.java:15031)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.view.ViewGroup.dispatchDraw(ViewGroup.java:3199)
android.view.View.draw(View.java:15031)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.view.ViewGroup.dispatchDraw(ViewGroup.java:3199)
com.taobao.weex.ui.view.WXFrameLayout.dispatchDraw(WXFrameLayout.java:109)
android.view.View.draw(View.java:15131)
android.widget.FrameLayout.draw(FrameLayout.java:592)
android.view.View.draw(View.java:15036)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.view.ViewGroup.dispatchDraw(ViewGroup.java:3199)
android.view.View.draw(View.java:15131)
android.widget.FrameLayout.draw(FrameLayout.java:592)
android.view.View.draw(View.java:15036)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.view.ViewGroup.dispatchDraw(ViewGroup.java:3199)
android.view.View.draw(View.java:15131)
android.view.View.draw(View.java:15036)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.view.ViewGroup.dispatchDraw(ViewGroup.java:3199)
android.view.View.draw(View.java:15031)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.view.ViewGroup.dispatchDraw(ViewGroup.java:3199)
android.view.View.draw(View.java:15031)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.view.ViewGroup.dispatchDraw(ViewGroup.java:3199)
android.view.View.draw(View.java:15031)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.view.ViewGroup.dispatchDraw(ViewGroup.java:3199)
android.view.View.draw(View.java:15031)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.view.ViewGroup.dispatchDraw(ViewGroup.java:3199)
android.view.View.draw(View.java:15031)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.view.ViewGroup.dispatchDraw(ViewGroup.java:3199)
android.view.View.draw(View.java:15031)
android.view.ViewGroup.drawChild(ViewGroup.java:3405)
android.view.ViewGroup.dispatchDraw(ViewGr
[Java stack is truncated for it exceeds the max size.]

By searching the source code, here we find this problem can be bypassed：
SkDraw::drawPath(const SkPath& origSrcPath, const SkPaint& origPaint, const SkMatrix* prePathMatrix, bool pathIsMutable, bool drawCoverage)

if (doFill) {
    if (paint->isAntiAlias()) {
        proc = SkScan::AntiFillPath;
    } else {
        proc = SkScan::FillPath;
    }
} else {    // hairline
    if (paint->isAntiAlias()) {
        proc = SkScan::AntiHairPath;
    } else {
        proc = SkScan::HairPath;
    }
}
so we set antiAlias false to skip AntiFillPath and solve this crash