### PR TITLE
[WEEX-200][iOS] deprecate wxcallback and wxmodulecallback

### DIFF
--- a/ios/playground/WeexDemo/extend/module/WXEventModule.m
+++ b/ios/playground/WeexDemo/extend/module/WXEventModule.m
@@ -55,12 +55,12 @@ WX_EXPORT_METHOD(@selector(fireNativeGlobalEvent:callback:))
  a test method for macaca case, you can fire globalEvent when download finish、device shaked and so on.
  @param event event name
  */
-- (void)fireNativeGlobalEvent:(NSString *)event callback:(WXModuleCallback)callback
+- (void)fireNativeGlobalEvent:(NSString *)event callback:(WXKeepAliveCallback)callback
 {
     [weexInstance fireGlobalEvent:event params:@{@"eventParam":@"eventValue"}];
     if (callback) {
         NSDictionary * result = @{@"ok": @true};
-        callback(result);
+        callback(result,false);
     }
 }
 

--- a/ios/sdk/WeexSDK/Sources/Model/WXComponent.h
+++ b/ios/sdk/WeexSDK/Sources/Model/WXComponent.h
@@ -32,7 +32,7 @@ typedef enum : NSUInteger {
  * @abstract the component callback , result can be string or dictionary.
  * @discussion callback data to js, the id of callback function will be removed to save memory.
  */
-typedef void (^WXCallback)(_Nonnull id result);
+typedef void (^WXCallback)(_Nonnull id result) DEPRECATED_MSG_ATTRIBUTE("use WXKeepAliveCallback, you can specify keep the callback or not, if keeped, it can be called multi times, or it will be removed after called.");
 
 /**
  * @abstract the component callback , result can be string or dictionary.

--- a/ios/sdk/WeexSDK/Sources/Protocol/WXModuleProtocol.h
+++ b/ios/sdk/WeexSDK/Sources/Protocol/WXModuleProtocol.h
@@ -34,7 +34,7 @@
  * @abstract the module callback , result can be string or dictionary.
  * @discussion callback data to js, the id of callback function will be removed to save memory.
  */
-typedef void (^WXModuleCallback)(id result);
+typedef void (^WXModuleCallback)(id result) DEPRECATED_MSG_ATTRIBUTE("use WXModuleKeepAliveCallback, you can specify keep the callback or not, if keeped, it can be called multi times, or it will be removed after called.");
 
 /**
  * @abstract the module callback , result can be string or dictionary.


### PR DESCRIPTION
As iOS  developers knows, we cannot distinguish the block by its params count, but it has been a time we use the default value of block parameter, I find out  that the default value could be dirty data.

here is the callback type  definition.

typedef void (^WXCallback)(_Nonnull id result)

typedef void (^WXKeepAliveCallback)(_Nonnull id result, BOOL keepAlive);

when the method called, weexSDK will set the callback according to the @encode result,

but these two type's encode result are all "?", see more encode result from Apple Documents https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html

Bug:200
