### PR TITLE
[WEEX-203][Android] base64 font-face support

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/common/Constants.java
+++ b/android/sdk/src/main/java/com/taobao/weex/common/Constants.java
@@ -341,6 +341,7 @@ public class Constants {
     String HTTPS = "https";
     String HTTP = "http";
     String LOCAL = "local";
+    String DATA = "data";
   }
 
   public interface CodeCache {

--- a/android/sdk/src/main/java/com/taobao/weex/utils/TypefaceUtil.java
+++ b/android/sdk/src/main/java/com/taobao/weex/utils/TypefaceUtil.java
@@ -139,7 +139,8 @@ public class TypefaceUtil {
       } else if (fontDo.getType() == FontDO.TYPE_NETWORK) {
         final String url = fontDo.getUrl();
         final String fontFamily = fontDo.getFontFamilyName();
-        final String fileName = url.replace('/', '_').replace(':', '_');
+        final String fileName = WXFileUtils.md5(url);
+        //url.replace('/', '_').replace(':', '_');
         File dir = new File(getFontCacheDir());
         if(!dir.exists()){
           dir.mkdirs();
@@ -148,7 +149,7 @@ public class TypefaceUtil {
         if (!loadLocalFontFile(fullPath, fontFamily, false)) {
           downloadFontByNetwork(url, fullPath, fontFamily);
         }
-      } else if (fontDo.getType() == FontDO.TYPE_FILE) {
+      } else if (fontDo.getType() == FontDO.TYPE_FILE || fontDo.getType() == FontDO.TYPE_BASE64) {
         boolean result = loadLocalFontFile(fontDo.getUrl(), fontDo.getFontFamilyName(), false);
         if (!result) {
           fontDo.setState(FontDO.STATE_FAILED);
@@ -274,6 +275,6 @@ public class TypefaceUtil {
   }
 
   private static String getFontCacheDir() {
-    return WXEnvironment.getDiskCacheDir(WXEnvironment.getApplication()) + "/" + FONT_CACHE_DIR_NAME;
+    return WXEnvironment.getApplication().getCacheDir() + "/" + FONT_CACHE_DIR_NAME;
   }
 }


### PR DESCRIPTION
- support `url('data:font/truetype;charset=utf-8;base64,...')` to import font-face
- change the font file cache directory from external storage to application cache

Testcase:
http://dotwe.org/vue/6472fc77dff5afda68864c070643f5ce