### PR TITLE
[WEEX-204][iOS] bugfix about longpress and pangesture innner waterfall component

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/Recycler/WXRecyclerComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/Recycler/WXRecyclerComponent.m
@@ -145,15 +145,14 @@ typedef enum : NSUInteger {
         _updateController.delegate = self;
         [self fixFlicker];
         
-        _dragController = [WXRecyclerDragController new];
-        _dragController.delegate = self;
         if ([attributes[@"draggable"] boolValue]) {
+            // lazy load
+            _dragController = [WXRecyclerDragController new];
+            _dragController.delegate = self;
             if([attributes[@"dragTriggerType"]  isEqual: @"pan"]){
                 _dragController.dragTriggerType = WXRecyclerDragTriggerPan;
             }
             _dragController.isDragable = YES;
-        }else{
-            _dragController.isDragable = NO;
         }
     }
     
@@ -212,11 +211,15 @@ typedef enum : NSUInteger {
         BOOL needUpdateLayout = NO;
         
         if ([attributes[@"draggable"] boolValue]) {
+            if (!_dragController) {  // lazy load
+                _dragController = [WXRecyclerDragController new];
+                _dragController.delegate = self;
+            }
             if([attributes[@"dragTriggerType"]  isEqual: @"pan"]){
                 _dragController.dragTriggerType = WXRecyclerDragTriggerPan;
             }
             _dragController.isDragable = YES;
-        }else{
+        } else {
             _dragController.isDragable = NO;
         }
         


### PR DESCRIPTION
 watterfall add a longpress and pan gesture for drag dataSource, so make it
lazy load so that it take no effect on user who don't care about the drag
dataSource, you can reproduce it by the follow case
http://dotwe.org/vue/4444eae2b4257b787dd5b82051aff2c5

Bug: 204
