### PR TITLE
* [android] close #123, websocket operate on main thread

### DIFF
--- a/android/commons/src/main/java/com/alibaba/weex/commons/adapter/DefaultWebSocketAdapter.java
+++ b/android/commons/src/main/java/com/alibaba/weex/commons/adapter/DefaultWebSocketAdapter.java
@@ -138,45 +138,60 @@ public class DefaultWebSocketAdapter implements IWebSocketAdapter {
     }
 
     @Override
-    public void send(String data) {
+    public void send(final String data) {
         if (ws != null) {
-            try {
-                Buffer buffer = new Buffer().writeUtf8(data);
-                ws.sendMessage(WebSocket.PayloadType.TEXT, buffer.buffer());
-                buffer.flush();
-                buffer.close();
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        Buffer buffer = new Buffer().writeUtf8(data);
+                        ws.sendMessage(WebSocket.PayloadType.TEXT, buffer.buffer());
+                        buffer.flush();
+                        buffer.close();
 
-                wsEventReporter.frameSent(data);
-            } catch (Exception e) {
-                e.printStackTrace();
-                reportError(e.getMessage());
-                wsEventReporter.frameError(e.getMessage());
-            }
+                        wsEventReporter.frameSent(data);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        reportError(e.getMessage());
+                        wsEventReporter.frameError(e.getMessage());
+                    }
+                }
+            }).start();
         } else {
             reportError("WebSocket is not ready");
         }
     }
 
     @Override
-    public void close(int code, String reason) {
+    public void close(final int code, final String reason) {
         if (ws != null) {
-            try {
-                ws.close(code, reason);
-            } catch (Exception e) {
-                e.printStackTrace();
-                reportError(e.getMessage());
-            }
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        ws.close(code, reason);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        reportError(e.getMessage());
+                    }
+                }
+            }).start();
         }
     }
 
     @Override
     public void destroy() {
         if (ws != null) {
-            try {
-                ws.close(WebSocketCloseCodes.CLOSE_GOING_AWAY.getCode(), WebSocketCloseCodes.CLOSE_GOING_AWAY.name());
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        ws.close(WebSocketCloseCodes.CLOSE_GOING_AWAY.getCode(), WebSocketCloseCodes.CLOSE_GOING_AWAY.name());
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            }).start();
         }
     }
 


### PR DESCRIPTION
DefaultWebSocketAdapter will throw an exception when run on android 7.0

[https://developer.android.com/about/versions/nougat/android-7.0-changes.html](url)

> Due to a bug in previous versions of Android, the system did not flag writing to a TCP socket on the main thread as a strict-mode violation. Android 7.0 fixes this bug. Apps that exhibit this behavior now throw an android.os.NetworkOnMainThreadException. Generally, performing network operations on the main thread is a bad idea because these operations usually have a high tail latency that causes ANRs and jank.