### PR TITLE
[jsfm] Stop using ES6 Proxy to require a module

### DIFF
--- a/runtime/api/WeexInstance.js
+++ b/runtime/api/WeexInstance.js
@@ -94,20 +94,18 @@ export default class WeexInstance {
       }
 
       // create module Proxy
-      if (typeof Proxy === 'function') {
-        moduleProxies[proxyName] = new Proxy(moduleApis, {
-          get (target, methodName) {
-            if (methodName in target) {
-              return target[methodName]
-            }
-            console.warn(`[JS Framework] using unregistered method "${moduleName}.${methodName}"`)
-            return moduleGetter(id, moduleName, methodName)
-          }
-        })
-      }
-      else {
-        moduleProxies[proxyName] = moduleApis
-      }
+      // if (typeof Proxy === 'function') {
+      //   moduleProxies[proxyName] = new Proxy(moduleApis, {
+      //     get (target, methodName) {
+      //       if (methodName in target) {
+      //         return target[methodName]
+      //       }
+      //       console.warn(`[JS Framework] using unregistered method "${moduleName}.${methodName}"`)
+      //       return moduleGetter(id, moduleName, methodName)
+      //     }
+      //   })
+      // }
+      moduleProxies[proxyName] = moduleApis
     }
 
     return moduleProxies[proxyName]


### PR DESCRIPTION
Using native `Proxy` will cause strange behavior in some old mobile devices. They offered the `Proxy` object but the behavior is not exactly same as the spec.