### PR TITLE
[WEEX-212][android] When PlaceHolder is empty, should not use rewrite

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/adapter/DefaultUriAdapter.java
+++ b/android/sdk/src/main/java/com/taobao/weex/adapter/DefaultUriAdapter.java
@@ -47,6 +47,9 @@ public class DefaultUriAdapter implements URIAdapter {
    if (uri.isRelative()) {
       //When uri is empty, means use the base url instead. Web broswer behave this way.
       if(uri.getEncodedPath().length() == 0){
+        if(TextUtils.isEmpty(uri.toString())){
+          return uri;
+        }
         return base;
       } else {
         resultBuilder = buildRelativeURI(resultBuilder, base, uri);

--- a/android/sdk/src/main/java/com/taobao/weex/adapter/DefaultUriAdapter.java
+++ b/android/sdk/src/main/java/com/taobao/weex/adapter/DefaultUriAdapter.java
@@ -47,8 +47,10 @@ public class DefaultUriAdapter implements URIAdapter {
    if (uri.isRelative()) {
       //When uri is empty, means use the base url instead. Web broswer behave this way.
       if(uri.getEncodedPath().length() == 0){
-        if(TextUtils.isEmpty(uri.toString())){
-          return uri;
+        if(URIAdapter.IMAGE.equals(type)){
+          if(TextUtils.isEmpty(uri.toString())){
+            return uri;
+          }
         }
         return base;
       } else {

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXImage.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXImage.java
@@ -332,7 +332,7 @@ public class WXImage extends WXComponent<ImageView> {
         }else if(getDomObject().getAttrs().containsKey(Constants.Name.PLACE_HOLDER)){
             placeholder=(String)getDomObject().getAttrs().get(Constants.Name.PLACE_HOLDER);
         }
-        if(placeholder!=null){
+        if(!TextUtils.isEmpty(placeholder)){
             imageStrategy.placeHolder = getInstance().rewriteUri(Uri.parse(placeholder),URIAdapter.IMAGE).toString();
         }
 

--- a/android/sdk/src/test/java/com/taobao/weex/adapter/DefaultUriAdapterTest.java
+++ b/android/sdk/src/test/java/com/taobao/weex/adapter/DefaultUriAdapterTest.java
@@ -110,7 +110,7 @@ public class DefaultUriAdapterTest {
     assertEquals(Uri.parse(host + "/test2"), uri);
 
     uri = adapter.rewrite(instance, URIAdapter.IMAGE, Uri.parse(""));
-    assertEquals(Uri.parse(bundleUrl), uri);
+    assertEquals(Uri.parse(""), uri);
   }
 
 }


### PR DESCRIPTION
[WEEX-212][android] When PlaceHolder is empty, should not use rewrite