### PR TITLE
[WEEX-233][iOS] More enhanced about <web> component

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.h
+++ b/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.h
@@ -23,6 +23,8 @@
 
 - (void)notifyWebview:(NSDictionary *) data;
 
+- (void)postMessage:(NSDictionary *) data;
+
 - (void)reload;
 
 - (void)goBack;

--- a/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.m
@@ -51,6 +51,9 @@
 
 @property (nonatomic, strong) NSString *source;
 
+// save source during this initialization
+@property (nonatomic, strong) NSString *inInitsource;
+
 @property (nonatomic, assign) BOOL startLoadEvent;
 
 @property (nonatomic, assign) BOOL finishLoadEvent;
@@ -63,6 +66,7 @@
 
 @implementation WXWebComponent
 
+WX_EXPORT_METHOD(@selector(postMessage:))
 WX_EXPORT_METHOD(@selector(goBack))
 WX_EXPORT_METHOD(@selector(reload))
 WX_EXPORT_METHOD(@selector(goForward))
@@ -73,7 +77,7 @@ WX_EXPORT_METHOD(@selector(goForward))
         self.url = attributes[@"src"];
         
         if(attributes[@"source"]){
-            self.source = attributes[@"source"];
+            self.inInitsource = attributes[@"source"];
         }
         
     }
@@ -127,10 +131,9 @@ WX_EXPORT_METHOD(@selector(goForward))
         [weakSelf fireEvent:@"message" params:initDic];
     };
 
+    self.source = _inInitsource;
     if (_url) {
         [self loadURL:_url];
-    }else if(_source){
-        [_webview loadHTMLString:_source baseURL:nil];
     }
 }
 
@@ -139,11 +142,10 @@ WX_EXPORT_METHOD(@selector(goForward))
     if (attributes[@"src"]) {
         self.url = attributes[@"src"];
     }
-    
-    if(attributes[@"source"]){
-        self.source=attributes[@"source"];
+
+    if (attributes[@"source"]) {
+        self.source = attributes[@"source"];
     }
-    
 }
 
 - (void)addEvent:(NSString *)eventName
@@ -178,7 +180,7 @@ WX_EXPORT_METHOD(@selector(goForward))
 - (void) setSource:(NSString *)source
 {
     NSString *newSource=[source copy];
-    if(!newSource){
+    if(!newSource || _url){
         return;
     }
     if(![newSource isEqualToString:_source]){

--- a/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.m
@@ -229,7 +229,7 @@ WX_EXPORT_METHOD(@selector(goForward))
 - (void)postMessage:(NSDictionary *)data {
     WXSDKInstance *instance = [WXSDKEngine topInstance];
 
-    NSMutableString *bundleUrlOrigin = @"";
+    NSString *bundleUrlOrigin = @"";
 
     if (instance.pageName) {
         NSString *bundleUrl = [instance.scriptURL absoluteString];
@@ -245,7 +245,7 @@ WX_EXPORT_METHOD(@selector(goForward))
 
     NSString *json = [WXUtility JSONString:initDic];
 
-    NSString *code = [NSString stringWithFormat:@"(function (){document.dispatchEvent(new MessageEvent('message', %@));}())", json];
+    NSString *code = [NSString stringWithFormat:@"(function (){window.dispatchEvent(new MessageEvent('message', %@));}())", json];
     [_jsContext evaluateScript:code];
 }
 

--- a/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.m
@@ -144,6 +144,7 @@ WX_EXPORT_METHOD(@selector(goForward))
     }
 
     if (attributes[@"source"]) {
+        self.inInitsource = attributes[@"source"];
         self.source = attributes[@"source"];
     }
 }

--- a/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.m
@@ -145,7 +145,7 @@ WX_EXPORT_METHOD(@selector(goForward))
 
     if (attributes[@"source"]) {
         self.inInitsource = attributes[@"source"];
-        self.source = attributes[@"source"];
+        self.source = self.inInitsource;
     }
 }
 

--- a/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.m
@@ -205,7 +205,8 @@ WX_EXPORT_METHOD(@selector(goForward))
     [_jsContext evaluateScript:code];
 }
 
-- (void)postMessage:(NSDictionary *)data {
+- (void)postMessage:(NSDictionary *)data
+{
     NSDictionary *eventDict = @{ @"data" : data };
     NSString *json = [WXUtility JSONString:eventDict];
     NSString *code = [NSString stringWithFormat:@"(function (){document.dispatchEvent(new MessageEvent('message', %@));}())",json];

--- a/ios/sdk/WeexSDK/Sources/Module/WXWebViewModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXWebViewModule.m
@@ -27,6 +27,7 @@
 @synthesize weexInstance;
 
 WX_EXPORT_METHOD(@selector(notifyWebview:data:))
+WX_EXPORT_METHOD(@selector(postMessage:data:))
 WX_EXPORT_METHOD(@selector(reload:))
 WX_EXPORT_METHOD(@selector(goBack:))
 WX_EXPORT_METHOD(@selector(goForward:))
@@ -59,6 +60,13 @@ WX_EXPORT_METHOD(@selector(goForward:))
         [webview notifyWebview:data];
     }];
 }
+
+- (void)postMessage:(NSString *)elemRef data:(NSDictionary *)data {
+    [self performBlockWithWebView:elemRef block:^void (WXWebComponent *webview) {
+        [webview postMessage:data];
+    }];
+}
+
 
 - (void)reload:(NSString *)elemRef {
     [self performBlockWithWebView:elemRef block:^void (WXWebComponent *webview) {


### PR DESCRIPTION
Hi, I'm Tw93(侑夕) from [Fliggy](https://www.fliggy.com/), I'd like to discuss the enhancements about [<Web>](https://weex.apache.org/references/components/web.html) component, let it take over where we can't implement through weex.

## Target

`<web>` is used to display web content that specified by src attribute in weex page,We also can use webview module to control WebView behavior such as goBack, goForward and reload.

But it's not enough in most businesses，I think a more enhanced web component should have the following:

* Support to send messages from Weex to a html in <web> component.
* Support to send messages from a html in <web> component to Weex.
* Support to render html source.


Previously, <web> component was an island that only rendered a remote url, but enabled it to communicate through the context native to the webView. Then I'm going to describe the solution that I came up with.

## My solution

### Code
* Weex iOS:
  * [WXWebComponent.m](https://github.com/tw93/incubator-weex/blob/ios-feature-enhanced-web/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.m)
  * [WXWebComponent.h](https://github.com/tw93/incubator-weex/blob/ios-feature-enhanced-web/ios/sdk/WeexSDK/Sources/Component/WXWebComponent.h)
  * [WXWebViewModule.m](https://github.com/tw93/incubator-weex/blob/ios-feature-enhanced-web/ios/sdk/WeexSDK/Sources/Module/WXWebViewModule.m)
* Weex Vue Demo:
  * [http://dotwe.org/vue/3576ed477d21dc020e63bf57dc414fff](http://dotwe.org/vue/3576ed477d21dc020e63bf57dc414fff)
  * [Demo Bundle JS](http://dotwe.org/raw/dist/3576ed477d21dc020e63bf57dc414fff.bundle.wx)
  * [Web End](http://h5.m.taobao.com/trip/wx-detection-demo/web.html)

### [Demo](https://gw.alipayobjects.com/zos/rmsportal/sBfTGamezxaBCGPshyXT.gif) && [Theory](https://img.alicdn.com/tfs/TB1hEhXbxGYBuNjy0FnXXX5lpXa-1872-1208.png)

<table><tr><td><img src="https://gw.alipayobjects.com/zos/rmsportal/sBfTGamezxaBCGPshyXT.gif" width="240"></td><td><img src="https://img.alicdn.com/tfs/TB1hEhXbxGYBuNjy0FnXXX5lpXa-1872-1208.png" width="600"></td></tr></table>


### Details

#### Support to send messages from Weex to a html in <web> component.

* Native：(W3c [MessageEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent))
 
  ```
   // Weex postMessage to web
  - (void)postMessage:(NSDictionary *)data {
      WXSDKInstance *instance = [WXSDKEngine topInstance];
  
      NSMutableString *bundleUrlOrigin = @"";
  
      if (instance.pageName) {
          NSString *bundleUrl = [instance.scriptURL absoluteString];
          NSURL *url = [NSURL URLWithString:bundleUrl];
          bundleUrlOrigin = [NSString stringWithFormat:@"%@://%@%@", url.scheme, url.host, url.port ? [NSString stringWithFormat:@":%@", url.port] : @""];
      }
  
      NSDictionary *initDic = @{
          @"type" : @"message",
          @"data" : data,
          @"origin" : bundleUrlOrigin
      };
  
      NSString *json = [WXUtility JSONString:initDic];
  
      NSString *code = [NSString stringWithFormat:@"(function (){window.dispatchEvent(new MessageEvent('message', %@));}())", json];
      [_jsContext evaluateScript:code];
  }
  ```
  
* How to use：
 
  ```
    // Weex
    const webview = weex.requireModule('webview');
    // recommend
    this.$refs['wxc-web'].postMessage({ detail: "a message" });
    //not recommend
    //webview.postMessage(this.$refs.webview, {detail:"a message"});
  
    // Web 
    window.addEventListener('message',function(e){
    console.log(e.data,e.type,e.origin); // { detail: "a message" },"message","*"
  },false)
  ```


#### Support to send messages from a html in <web> component to Weex.

- Native：(W3c [MessageEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent))

  ```
  //Weex catch postMessage event from web
      _jsContext[@"postMessage"] = ^() {
  
          NSArray *args = [JSContext currentArguments];
  
          if (args && args.count < 2) {
              return;
          }
  
          NSDictionary *data = [args[0] toDictionary];
          NSString *origin = [args[1] toString];
  
          if (data == nil) {
              return;
          }
  
          NSDictionary *initDic = @{ @"type" : @"message",
                                     @"data" : data,
                                     @"origin" : origin
          };
  
          [weakSelf fireEvent:@"message" params:initDic];
      };
  ```

- How to use：

  ```
    // Weex
    <web @message="onMessage"></web>
    
     onMessage (e) {
            console.log(e.data,e.type,e.origin); // { detail: "a message" },"message","*"
      },
    
    // Web iframe
      window.parent.postMessage({ detail: "a message" }, '*');
  ``` 


#### Support to render html source.

* Native:
 
  ```
  [_webview loadHTMLString:_source baseURL:nil];
  ```
* How to use:
 
  ```html
  <web source='<p style="text-align: center;"><img align="absmiddle" src="http://img03.taobaocdn.com/imgextra/i3/1124701655/TB2zmmIcpXXXXbIXpXXXXXXXXXX_!!1124701655.jpg"/></p>'></web>
  ```

Welcome to put forward any suggestion about the solution or other requirements for the <web> component, Thanks！