### PR TITLE
[WEEX-249][iOS]fix WXRuleManager multi-thread crash

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Manager/WXRuleManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXRuleManager.m
@@ -89,7 +89,7 @@ static WXRuleManager *_sharedInstance = nil;
                 return;
             }
             if (!fontFamily) {
-                fontFamily = [WXThreadSafeMutableDictionary dictionary];
+                fontFamily = [[WXThreadSafeMutableDictionary alloc] init];
             }
             NSURL *fontURL = [NSURL URLWithString:fontSrc];
             if (!fontURL) {

--- a/ios/sdk/WeexSDK/Sources/Manager/WXRuleManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXRuleManager.m
@@ -83,13 +83,13 @@ static WXRuleManager *_sharedInstance = nil;
             }
             
             fontSrc = newURL;
-            NSMutableDictionary * fontFamily = [self.fontStorage objectForKey:rule[@"fontFamily"]];
+            WXThreadSafeMutableDictionary * fontFamily = [self.fontStorage objectForKey:rule[@"fontFamily"]];
             if (fontFamily && [fontFamily[@"tempSrc"] isEqualToString:fontSrc]) {
                 // if the new src is same as src in dictionary , ignore it, or update it
                 return;
             }
             if (!fontFamily) {
-                fontFamily = [NSMutableDictionary dictionary];
+                fontFamily = [WXThreadSafeMutableDictionary dictionary];
             }
             NSURL *fontURL = [NSURL URLWithString:fontSrc];
             if (!fontURL) {
@@ -114,7 +114,7 @@ static WXRuleManager *_sharedInstance = nil;
             [WXUtility getIconfont:fontURL completion:^(NSURL * _Nonnull url, NSError * _Nullable error) {
                 if (!error && url) {
                     // load success
-                    NSMutableDictionary * dictForFontFamily = [weakSelf.fontStorage objectForKey:rule[@"fontFamily"]];
+                    WXThreadSafeMutableDictionary * dictForFontFamily = [weakSelf.fontStorage objectForKey:rule[@"fontFamily"]];
                     NSString *fontSrc = [dictForFontFamily objectForKey:@"tempSrc"];
                     if (fontSrc) {
                         // only remote font will be mark as tempSrc


### PR DESCRIPTION
fontFamilyDic type is WXThreadSafeMutableDictionary in WXUtility.m but the real type is NSMutableDictionary created in WXRuleManager.m.

It may cause crash in multi-thread.