### PR TITLE
[Weex-260][iOS]switch supports setting color

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXSwitchComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXSwitchComponent.m
@@ -36,6 +36,16 @@
 @property (nonatomic, assign)   BOOL    checked;
 @property (nonatomic, assign)   BOOL    disabled;
 
+//Background color when the switch is turned on.
+@property (nonatomic, strong)  UIColor *onTintColor;
+
+
+//Color of the foreground switch grip.
+@property (nonatomic, strong)  UIColor *thumbTintColor;
+
+//Border color and background color on Android when the switch is turned off
+@property (nonatomic, strong)  UIColor *tintColor;
+
 @end
 
 @implementation WXSwitchComponent
@@ -45,6 +55,18 @@
     if (self = [super initWithRef:ref type:type styles:styles attributes:attributes events:events weexInstance:weexInstance]) {
         _checked = attributes[@"checked"] ? [WXConvert BOOL:attributes[@"checked"]] : NO;
         _disabled = attributes[@"disabled"] ? [WXConvert BOOL:attributes[@"disabled"]] : NO;
+        
+        if(attributes[@"onTintColor"]){
+            _onTintColor = [WXConvert UIColor:attributes[@"onTintColor"]];
+        }
+
+        if(attributes[@"thumbTintColor"]){
+            _thumbTintColor = [WXConvert UIColor:attributes[@"thumbTintColor"]];
+        }
+
+        if(attributes[@"tintColor"]){
+            _tintColor = [WXConvert UIColor:attributes[@"tintColor"]];
+        }
         
         self.cssNode->style.dimensions[CSS_WIDTH] = 51;
         self.cssNode->style.dimensions[CSS_HEIGHT] = 31;
@@ -64,6 +86,18 @@
     [_switchView setOn:_checked animated:YES];
     [_switchView setEnabled:!_disabled];
     [_switchView addTarget:self action:@selector(checkChanged) forControlEvents:UIControlEventValueChanged];
+    
+    if(_onTintColor){
+        _switchView.onTintColor = _onTintColor;
+    }
+
+    if(_tintColor){
+        _switchView.tintColor = _tintColor;
+    }
+
+    if(_thumbTintColor){
+        _switchView.thumbTintColor = _thumbTintColor;
+    }
 }
 
 - (void)addEvent:(NSString *)eventName
@@ -89,6 +123,21 @@
     else if (attributes[@"disabled"]) {
         _disabled = [WXConvert BOOL:attributes[@"disabled"]];
         [_switchView setEnabled:!_disabled];
+    }
+    
+    if(attributes[@"onTintColor"]){
+        _onTintColor = [WXConvert UIColor:attributes[@"onTintColor"]];
+        _switchView.onTintColor = _onTintColor;
+    }
+    
+    if(attributes[@"thumbTintColor"]){
+        _thumbTintColor = [WXConvert UIColor:attributes[@"thumbTintColor"]];
+        _switchView.thumbTintColor = _thumbTintColor;
+    }
+    
+    if(attributes[@"tintColor"]){
+        _tintColor = [WXConvert UIColor:attributes[@"tintColor"]];
+        _switchView.tintColor = _tintColor;
     }
 }
 


### PR DESCRIPTION
## Background
- Currently, the [`<switch>`](http://weex-project.io/cn/references/components/switch.html) component in Weex only support the default green color, But many times the business needs to set color for the theme tone of the product, So <switch> needs to support setting the color.


## New Support &&  Demo
- tintColor: Background color when the switch is turned on.
- onTintColor: Border color and background color on Android when the switch is turned off.
- thumbTintColor: Color of the foreground switch grip.

<table><tr><td><img src="https://gw.alipayobjects.com/zos/rmsportal/echgZhufHYAqYQSSSyKJ.gif" width="240"></td><td><img src="https://gw.alipayobjects.com/zos/rmsportal/zlyOBlQnVbloIizCdWKU.gif" width="240"></td></tr></table>

## How to Use

```
<switch on-tint-color="#C33D3E" 
        thumb-tint-color="#FF7703" 
        tint-color="#850B0B" 
        checked="true"></switch>
```

## My solution
#### Code
* Weex iOS:
  * [WXSwitchComponent.m](https://github.com/tw93/incubator-weex/blob/ios-feature-switch/ios/sdk/WeexSDK/Sources/Component/WXSwitchComponent.m)
* Weex Vue Demo:
  * [http://dotwe.org/vue/99a13cce5a429c7b9bce9bea24253935](http://dotwe.org/vue/99a13cce5a429c7b9bce9bea24253935)
  * [Demo Bundle JS](http://dotwe.org/raw/dist/99a13cce5a429c7b9bce9bea24253935.bundle.wx)

#### Details

It can be overwritten with the `onTintColor`、`thumbTintColor`、`tintColor` attributes of `switchView`, as well as the job of updating the attributes.

```
...
_switchView.onTintColor = _onTintColor;
_switchView.thumbTintColor = _thumbTintColor;
_switchView.tintColor = _tintColor;
```


Welcome to put forward any suggestion about the solution or other requirements for the <switch> component, Thanks！