### PR TITLE
[Weex-260][android]switch supports setting color

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/common/Constants.java
+++ b/android/sdk/src/main/java/com/taobao/weex/common/Constants.java
@@ -207,8 +207,10 @@ public class Constants {
     String INCLUDE_FONT_PADDING = "includeFontPadding";
     String ENABLE_COPY = "enableCopy";
 
-
-
+    String THUMB_TINT_COLOR = "thumbTintColor";
+    String ON_THUMB_TINT_COLOR = "onThumbTintColor";
+    String TINT_COLOR = "tintColor";
+    String ON_TINT_COLOR = "onTintColor";
 
     interface  Recycler{
       String LIST_DATA = "listData";

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSwitch.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSwitch.java
@@ -23,7 +23,6 @@ import android.support.annotation.NonNull;
 import android.widget.CompoundButton;
 
 import com.taobao.weex.WXSDKInstance;
-import com.taobao.weex.WXSDKManager;
 import com.taobao.weex.annotation.Component;
 import com.taobao.weex.common.Constants;
 import com.taobao.weex.dom.WXDomObject;
@@ -38,6 +37,10 @@ import java.util.Map;
 public class WXSwitch extends WXComponent<WXSwitchView> {
 
   private CompoundButton.OnCheckedChangeListener mListener;
+  private String mTrackTintColorNormal;
+  private String mTrackTintColorActivated;
+  private String mThumbTintColorNormal;
+  private String mThumbTintColorActivated;
 
   @Deprecated
   public WXSwitch(WXSDKInstance instance, WXDomObject dom, WXVContainer parent, String instanceId, boolean isLazy) {
@@ -94,6 +97,22 @@ public class WXSwitch extends WXComponent<WXSwitchView> {
           setChecked(result);
         }
         return true;
+      case Constants.Name.THUMB_TINT_COLOR:
+        mThumbTintColorNormal = WXUtils.getString(param, null);
+        setThumbColor();
+        return true;
+      case Constants.Name.ON_THUMB_TINT_COLOR:
+        mThumbTintColorActivated = WXUtils.getString(param, null);
+        setThumbColor();
+        return true;
+      case Constants.Name.TINT_COLOR:
+        mTrackTintColorNormal = WXUtils.getString(param, null);
+        setTrackColor();
+        return true;
+      case Constants.Name.ON_TINT_COLOR:
+        mTrackTintColorActivated = WXUtils.getString(param, null);
+        setTrackColor();
+        return true;
     }
     return super.setProperty(key, param);
   }
@@ -103,5 +122,13 @@ public class WXSwitch extends WXComponent<WXSwitchView> {
     getHostView().setOnCheckedChangeListener(null);
     getHostView().setChecked(checked);
     getHostView().setOnCheckedChangeListener(mListener);
+  }
+
+  private void setThumbColor() {
+    getHostView().setThumbColor(mThumbTintColorNormal, mThumbTintColorActivated);
+  }
+
+  private void setTrackColor() {
+    getHostView().setTrackColor(mTrackTintColorNormal, mTrackTintColorActivated);
   }
 }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/WXSwitchView.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/WXSwitchView.java
@@ -19,14 +19,24 @@
 package com.taobao.weex.ui.view;
 
 import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
 import android.support.v7.widget.SwitchCompat;
 import android.view.Gravity;
 import android.view.MotionEvent;
 
 import com.taobao.weex.ui.view.gesture.WXGesture;
 import com.taobao.weex.ui.view.gesture.WXGestureObservable;
+import com.taobao.weex.utils.WXResourceUtils;
 
 public class WXSwitchView extends SwitchCompat implements WXGestureObservable {
+
+  static final String TRACK_TINT_COLOR_NORMAL = "#b9b8b8";
+  static final String TRACK_TINT_COLOR_ACTIVATED = "#fb97bd";
+  static final String TRACK_TINT_COLOR_DISABLED = "#42b9b8b8";
+  static final String THUMB_TINT_COLOR_NORMAL = "#f1f1f1";
+  static final String THUMB_TINT_COLOR_ACTIVATED = "#fc4482";
+  static final String THUMB_TINT_COLOR_DISABLED = "#42f1f1f1";
 
   private WXGesture wxGesture;
 
@@ -34,6 +44,7 @@ public class WXSwitchView extends SwitchCompat implements WXGestureObservable {
     super(context);
     setShowText(false);
     setGravity(Gravity.CENTER_VERTICAL);
+    setBackgroundColor(Color.TRANSPARENT);
   }
 
   @Override
@@ -48,5 +59,29 @@ public class WXSwitchView extends SwitchCompat implements WXGestureObservable {
       result |= wxGesture.onTouch(this, event);
     }
     return result;
+  }
+
+  public void setThumbColor(String thumbTintColorNormal, String thumbTintColorActivated) {
+    setThumbTintList(new ColorStateList(new int[][]{
+        new int[]{-android.R.attr.state_enabled},
+        new int[]{-android.R.attr.state_checked},
+        new int[]{android.R.attr.state_checked}
+    }, new int[]{
+        WXResourceUtils.getColor(THUMB_TINT_COLOR_DISABLED, Color.parseColor(THUMB_TINT_COLOR_DISABLED)),
+        WXResourceUtils.getColor(thumbTintColorNormal, Color.parseColor(THUMB_TINT_COLOR_NORMAL)),
+        WXResourceUtils.getColor(thumbTintColorActivated, Color.parseColor(THUMB_TINT_COLOR_ACTIVATED))
+    }));
+  }
+
+  public void setTrackColor(String trackTintColorNormal, String trackTintColorActivated) {
+    setTrackTintList(new ColorStateList(new int[][]{
+        new int[]{-android.R.attr.state_enabled},
+        new int[]{-android.R.attr.state_checked},
+        new int[]{android.R.attr.state_checked}
+    }, new int[]{
+        WXResourceUtils.getColor(TRACK_TINT_COLOR_DISABLED, Color.parseColor(TRACK_TINT_COLOR_DISABLED)),
+        WXResourceUtils.getColor(trackTintColorNormal, Color.parseColor(TRACK_TINT_COLOR_NORMAL)),
+        WXResourceUtils.getColor(trackTintColorActivated, Color.parseColor(TRACK_TINT_COLOR_ACTIVATED))
+    }));
   }
 }


### PR DESCRIPTION
Hi, It's solution to support setting color for `<switch>` component in android. And the api was according to [ios design](https://github.com/apache/incubator-weex/pull/1076), a slight difference is `<switch>` can accept 4 attributes in android:

||android|ios|
|---|---|---|
|tint-color|√|√|
|on-tint-color|√|√|
|thumb-tint-color|√|√|
|on-thumb-tint-color|√|×|

Weex Vue Demo: [http://dotwe.org/vue/e9d87730e016bec01225e546ff10ef0d](http://dotwe.org/vue/e9d87730e016bec01225e546ff10ef0d)