### PR TITLE
[WEEX-277][iOS]fixed textfield menuController delete case crash

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXTextInputComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextInputComponent.m
@@ -50,7 +50,26 @@
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
     // this behavior will hide the action like copy, cut, paste, selectAll and so on.
-    return [[self.wx_component valueForKey:@"allowCopyPaste"] boolValue];
+    // fixed textfield issue
+    BOOL allowCopyPaste = [[self.wx_component valueForKey:@"allowCopyPaste"] boolValue];
+    if (allowCopyPaste) {
+        if (action == @selector(cut:)) {
+            return YES;
+        }
+        if (action == @selector(copy:)) {
+            return YES;
+        }
+        if (action == @selector(paste:)) {
+            return YES;
+        }
+        if (action == @selector(select:)) {
+            return YES;
+        }
+        if (action == @selector(selectAll:)) {
+            return YES;
+        }
+    }
+    return NO;
 }
 
 - (CGRect)editingRectForBounds:(CGRect)bounds

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextInputComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextInputComponent.m
@@ -51,23 +51,10 @@
 {
     // this behavior will hide the action like copy, cut, paste, selectAll and so on.
     // fixed textfield issue
+    // fixed menu item show by system default(like: if word not be selected ,menu item not show "cut")
     BOOL allowCopyPaste = [[self.wx_component valueForKey:@"allowCopyPaste"] boolValue];
     if (allowCopyPaste) {
-        if (action == @selector(cut:)) {
-            return YES;
-        }
-        if (action == @selector(copy:)) {
-            return YES;
-        }
-        if (action == @selector(paste:)) {
-            return YES;
-        }
-        if (action == @selector(select:)) {
-            return YES;
-        }
-        if (action == @selector(selectAll:)) {
-            return YES;
-        }
+        return [super canPerformAction:action withSender:sender];
     }
     return NO;
 }


### PR DESCRIPTION
First of all, thank you for your contribution! 

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

CheckList:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update test scripts for the feature.
  * [ ] Add unit tests for the feature.
  * [ios] fixed WXTextInputView MenuController  menu item  "unrecognized selector sent to instance" like "delete" in protocol "UIResponderStandardEditActions"




