### PR TITLE
[WEEX-282][iOS] update layout system to support rtl direction

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Utility/WXConvert.h
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXConvert.h
@@ -40,6 +40,7 @@ typedef CGFloat WXPixelType;
 // @parameter scaleFactor: please use weexInstance's pixelScaleFactor property
 + (WXPixelType)WXPixelType:(id)value scaleFactor:(CGFloat)scaleFactor;
 
++ (css_direction_t)css_direction_t:(id)value;
 + (css_flex_direction_t)css_flex_direction_t:(id)value;
 + (css_align_t)css_align_t:(id)value;
 + (css_wrap_type_t)css_wrap_type_t:(id)value;

--- a/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
@@ -146,6 +146,20 @@ WX_NUMBER_CONVERT(NSUInteger, unsignedIntegerValue)
 
 #pragma mark CSS Layout
 
++ (css_direction_t)css_direction_t:(id)value
+{
+    if([value isKindOfClass:[NSString class]]){
+        if ([value isEqualToString:@"inherit"]) {
+            return CSS_DIRECTION_INHERIT;
+        } else if ([value isEqualToString:@"ltr"]) {
+            return CSS_DIRECTION_LTR;
+        } else if ([value isEqualToString:@"rtl"]) {
+            return CSS_DIRECTION_RTL;
+        }
+    }
+    return CSS_DIRECTION_LTR;
+}
+
 +(css_position_type_t)css_position_type_t:(id)value
 {
     if([value isKindOfClass:[NSString class]]){

--- a/ios/sdk/WeexSDKTests/WXConvertTests.m
+++ b/ios/sdk/WeexSDKTests/WXConvertTests.m
@@ -36,6 +36,14 @@
     [super tearDown];
 }
 
+- (void)testDirection {
+    NSArray *testDirections = @[@"inherit", @"ltr", @"rtl"];
+    css_direction_t directions[3] = {CSS_DIRECTION_INHERIT, CSS_DIRECTION_LTR, CSS_DIRECTION_RTL};
+    for (int i = 0; i<testDirections.count; i++) {
+        XCTAssertTrue([WXConvert wx_css_direction_t:testDirections[i]] == directions[i]);
+    }
+}
+
 - (void)testBOOL {
     // This is an example of a functional test case.
     // Use XCTAssert and related functions to verify your tests produce the correct results.


### PR DESCRIPTION
Update WXComponent+layout.m to support CSS "direction:rtl".
Few languages such as Arabic, Hebrew, or Persian are written from Right to Left, but weex not support RTL layouts. To handle them. Since this PR merged, we can use weex for RTL languages.


Modified WXComponent+Layout.m:
	1.set direction value to  cssNode
	2.setNeedLayout changed to trigger sibling component recalculate cssNode->layout

Modified WXConvert.h/m:
	add convert for "direction"

Modified WXConvertTests.m:
	add Tests for convert direction