### PR TITLE
[WEEX-286][iOS] try to resolve the crash of  dyld_stub_binder

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Utility/WXThreadSafeMutableArray.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXThreadSafeMutableArray.m
@@ -25,7 +25,6 @@
 @interface WXThreadSafeMutableArray () {
     pthread_mutex_t _safeThreadArrayMutex;
     pthread_mutexattr_t _safeThreadArrayMutexAttr;
-    os_unfair_lock _osUnfairLock;
 }
 
 @property (nonatomic, strong) dispatch_queue_t queue;
@@ -44,9 +43,6 @@
         pthread_mutexattr_init(&(_safeThreadArrayMutexAttr));
         pthread_mutexattr_settype(&(_safeThreadArrayMutexAttr), PTHREAD_MUTEX_RECURSIVE);
         pthread_mutex_init(&(_safeThreadArrayMutex), &(_safeThreadArrayMutexAttr));
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            _osUnfairLock = OS_UNFAIR_LOCK_INIT;
-        }
     }
     return self;
 }
@@ -107,15 +103,9 @@
             count = _array.count;
         });
     } else {
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            os_unfair_lock_lock(&_osUnfairLock);
-            count = [_array count];
-            os_unfair_lock_unlock(&_osUnfairLock);
-        } else {
-            pthread_mutex_lock(&_safeThreadArrayMutex);
-            count = [_array count];
-            pthread_mutex_unlock(&_safeThreadArrayMutex);
-        }
+        pthread_mutex_lock(&_safeThreadArrayMutex);
+        count = [_array count];
+        pthread_mutex_unlock(&_safeThreadArrayMutex);
     }
     return count;
 }
@@ -128,15 +118,9 @@
             obj = _array[index];
         });
     } else {
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            os_unfair_lock_lock(&_osUnfairLock);
-            obj = _array[index];
-            os_unfair_lock_unlock(&_osUnfairLock);
-        } else {
-            pthread_mutex_lock(&_safeThreadArrayMutex);
-            obj = _array[index];
-            pthread_mutex_unlock(&_safeThreadArrayMutex);
-        }
+        pthread_mutex_lock(&_safeThreadArrayMutex);
+        obj = _array[index];
+        pthread_mutex_unlock(&_safeThreadArrayMutex);
     }
     return obj;
 }
@@ -149,15 +133,9 @@
             enu = [_array objectEnumerator];
         });
     } else {
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            os_unfair_lock_lock(&_osUnfairLock);
-            enu = [_array objectEnumerator];
-            os_unfair_lock_unlock(&_osUnfairLock);
-        } else {
-            pthread_mutex_lock(&_safeThreadArrayMutex);
-            enu = [_array objectEnumerator];
-            pthread_mutex_unlock(&_safeThreadArrayMutex);
-        }
+        pthread_mutex_lock(&_safeThreadArrayMutex);
+        enu = [_array objectEnumerator];
+        pthread_mutex_unlock(&_safeThreadArrayMutex);
     }
     return enu;
 }
@@ -169,15 +147,9 @@
             [_array insertObject:anObject atIndex:index];
         });
     } else {
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            os_unfair_lock_lock(&_osUnfairLock);
-            [_array insertObject:anObject atIndex:index];
-            os_unfair_lock_unlock(&_osUnfairLock);
-        } else {
-            pthread_mutex_lock(&_safeThreadArrayMutex);
-            [_array insertObject:anObject atIndex:index];
-            pthread_mutex_unlock(&_safeThreadArrayMutex);
-        }
+        pthread_mutex_lock(&_safeThreadArrayMutex);
+        [_array insertObject:anObject atIndex:index];
+        pthread_mutex_unlock(&_safeThreadArrayMutex);
     }
 }
 
@@ -188,15 +160,9 @@
             [_array addObject:anObject];
         });
     } else {
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            os_unfair_lock_lock(&_osUnfairLock);
-            [_array addObject:anObject];
-            os_unfair_lock_unlock(&_osUnfairLock);
-        } else {
-            pthread_mutex_lock(&_safeThreadArrayMutex);
-            [_array addObject:anObject];
-            pthread_mutex_unlock(&_safeThreadArrayMutex);
-        }
+        pthread_mutex_lock(&_safeThreadArrayMutex);
+        [_array addObject:anObject];
+        pthread_mutex_unlock(&_safeThreadArrayMutex);
     }
 }
 
@@ -207,15 +173,9 @@
             [_array removeObjectAtIndex:index];
         });
     } else {
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            os_unfair_lock_lock(&_osUnfairLock);
-            [_array removeObjectAtIndex:index];
-            os_unfair_lock_unlock(&_osUnfairLock);
-        } else {
-            pthread_mutex_lock(&_safeThreadArrayMutex);
-            [_array removeObjectAtIndex:index];
-            pthread_mutex_unlock(&_safeThreadArrayMutex);
-        }
+        pthread_mutex_lock(&_safeThreadArrayMutex);
+        [_array removeObjectAtIndex:index];
+        pthread_mutex_unlock(&_safeThreadArrayMutex);
     }
 }
 
@@ -226,15 +186,9 @@
             [_array removeLastObject];
         });
     } else {
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            os_unfair_lock_lock(&_osUnfairLock);
-            [_array removeLastObject];
-            os_unfair_lock_unlock(&_osUnfairLock);
-        } else {
-            pthread_mutex_lock(&_safeThreadArrayMutex);
-            [_array removeLastObject];
-            pthread_mutex_unlock(&_safeThreadArrayMutex);
-        }
+        pthread_mutex_lock(&_safeThreadArrayMutex);
+        [_array removeLastObject];
+        pthread_mutex_unlock(&_safeThreadArrayMutex);
     }
 }
 
@@ -245,15 +199,9 @@
             [_array replaceObjectAtIndex:index withObject:anObject];
         });
     } else {
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            os_unfair_lock_lock(&_osUnfairLock);
-            [_array replaceObjectAtIndex:index withObject:anObject];
-            os_unfair_lock_unlock(&_osUnfairLock);
-        } else {
-            pthread_mutex_lock(&_safeThreadArrayMutex);
-            [_array replaceObjectAtIndex:index withObject:anObject];
-            pthread_mutex_unlock(&_safeThreadArrayMutex);
-        }
+        pthread_mutex_lock(&_safeThreadArrayMutex);
+        [_array replaceObjectAtIndex:index withObject:anObject];
+        pthread_mutex_unlock(&_safeThreadArrayMutex);
     }
 }
 
@@ -270,15 +218,9 @@
             }
         });
     } else {
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            os_unfair_lock_lock(&_osUnfairLock);
-            index = [_array indexOfObject:anObject];
-            os_unfair_lock_unlock(&_osUnfairLock);
-        } else {
-            pthread_mutex_lock(&_safeThreadArrayMutex);
-            index = [_array indexOfObject:anObject];
-            pthread_mutex_unlock(&_safeThreadArrayMutex);
-        }
+        pthread_mutex_lock(&_safeThreadArrayMutex);
+        index = [_array indexOfObject:anObject];
+        pthread_mutex_unlock(&_safeThreadArrayMutex);
     }
     
     return index;

--- a/ios/sdk/WeexSDK/Sources/Utility/WXThreadSafeMutableDictionary.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXThreadSafeMutableDictionary.m
@@ -26,7 +26,6 @@
 {
     pthread_mutex_t _safeThreadDictionaryMutex;
     pthread_mutexattr_t _safeThreadDictionaryMutexAttr;
-    os_unfair_lock _unfairLock;// this type of lock is not recurisive
 }
 
 @property (nonatomic, strong) dispatch_queue_t queue;
@@ -45,19 +44,11 @@ do { \
             }\
         });\
     } else {\
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {\
-            os_unfair_lock_lock(&_unfairLock);\
-            if ([_dict respondsToSelector:method]) {\
-                retValue = [_dict performSelector:method];\
-            }\
-            os_unfair_lock_unlock(&_unfairLock);\
-        } else {\
-            pthread_mutex_lock(&_safeThreadDictionaryMutex);\
-            if ([_dict respondsToSelector:method]) {\
-                retValue = [_dict performSelector:method];\
-            }\
-            pthread_mutex_unlock(&_safeThreadDictionaryMutex);\
+        pthread_mutex_lock(&_safeThreadDictionaryMutex);\
+        if ([_dict respondsToSelector:method]) {\
+            retValue = [_dict performSelector:method];\
         }\
+        pthread_mutex_unlock(&_safeThreadDictionaryMutex);\
     }\
     _Pragma("clang diagnostic pop")\
 } while (0)
@@ -73,9 +64,6 @@ do { \
         pthread_mutexattr_init(&(_safeThreadDictionaryMutexAttr));
         pthread_mutexattr_settype(&(_safeThreadDictionaryMutexAttr), PTHREAD_MUTEX_RECURSIVE);
         pthread_mutex_init(&(_safeThreadDictionaryMutex), &(_safeThreadDictionaryMutexAttr));
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            _unfairLock = OS_UNFAIR_LOCK_INIT;
-        }
     }
     return self;
 }
@@ -137,15 +125,9 @@ do { \
             count = _dict.count;
         });
     } else {
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            os_unfair_lock_lock(&_unfairLock);
-            count = [_dict count];
-            os_unfair_lock_unlock(&_unfairLock);
-        } else {
-            pthread_mutex_lock(&_safeThreadDictionaryMutex);
-            count = [_dict count];
-            pthread_mutex_unlock(&_safeThreadDictionaryMutex);
-        }
+        pthread_mutex_lock(&_safeThreadDictionaryMutex);
+        count = [_dict count];
+        pthread_mutex_unlock(&_safeThreadDictionaryMutex);
     }
     return count;
 }
@@ -161,15 +143,9 @@ do { \
             obj = _dict[aKey];
         });
     } else {
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            os_unfair_lock_lock(&_unfairLock);
-            obj = _dict[aKey];
-            os_unfair_lock_unlock(&_unfairLock);
-        } else {
-            pthread_mutex_lock(&_safeThreadDictionaryMutex);
-            obj = _dict[aKey];
-            pthread_mutex_unlock(&_safeThreadDictionaryMutex);
-        }
+        pthread_mutex_lock(&_safeThreadDictionaryMutex);
+        obj = _dict[aKey];
+        pthread_mutex_unlock(&_safeThreadDictionaryMutex);
     }
     return obj;
 }
@@ -182,15 +158,9 @@ do { \
             enu = [_dict keyEnumerator];
         });
     } else {
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            os_unfair_lock_lock(&_unfairLock);
-            enu = [_dict keyEnumerator];
-            os_unfair_lock_unlock(&_unfairLock);
-        } else {
-            pthread_mutex_lock(&_safeThreadDictionaryMutex);
-            enu = [_dict keyEnumerator];
-            pthread_mutex_unlock(&_safeThreadDictionaryMutex);
-        }
+        pthread_mutex_lock(&_safeThreadDictionaryMutex);
+        enu = [_dict keyEnumerator];
+        pthread_mutex_unlock(&_safeThreadDictionaryMutex);
     }
     return enu;
 }
@@ -203,15 +173,9 @@ do { \
         _dict[aKey] = anObject;
         });
     } else {
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            os_unfair_lock_lock(&_unfairLock);
-            _dict[aKey] = anObject;
-            os_unfair_lock_unlock(&_unfairLock);
-        }else {
-            pthread_mutex_lock(&_safeThreadDictionaryMutex);
-            _dict[aKey] = anObject;
-            pthread_mutex_unlock(&_safeThreadDictionaryMutex);
-        }
+        pthread_mutex_lock(&_safeThreadDictionaryMutex);
+        _dict[aKey] = anObject;
+        pthread_mutex_unlock(&_safeThreadDictionaryMutex);
     }
 }
 
@@ -236,15 +200,9 @@ do { \
             [_dict removeObjectForKey:aKey];
         });
     } else {
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            os_unfair_lock_lock(&_unfairLock);
-            [_dict removeObjectForKey:aKey];
-            os_unfair_lock_unlock(&_unfairLock);
-        }else {
-            pthread_mutex_lock(&_safeThreadDictionaryMutex);
-            [_dict removeObjectForKey:aKey];
-            pthread_mutex_unlock(&_safeThreadDictionaryMutex);
-        }
+        pthread_mutex_lock(&_safeThreadDictionaryMutex);
+        [_dict removeObjectForKey:aKey];
+        pthread_mutex_unlock(&_safeThreadDictionaryMutex);
     }
 }
 
@@ -255,15 +213,9 @@ do { \
             [_dict removeAllObjects];
         });
     }else {
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            os_unfair_lock_lock(&_unfairLock);
-            [_dict removeAllObjects];
-            os_unfair_lock_unlock(&_unfairLock);
-        } else {
-            pthread_mutex_lock(&_safeThreadDictionaryMutex);
-            [_dict removeAllObjects];
-            pthread_mutex_unlock(&_safeThreadDictionaryMutex);
-        }
+        pthread_mutex_lock(&_safeThreadDictionaryMutex);
+        [_dict removeAllObjects];
+        pthread_mutex_unlock(&_safeThreadDictionaryMutex);
     }
 }
 
@@ -274,15 +226,9 @@ do { \
             copyInstance = [_dict copy];
         });
     } else {
-        if (WX_SYS_VERSION_GREATER_THAN(@"10.0")) {
-            os_unfair_lock_lock(&_unfairLock);
-            copyInstance = [_dict copy];
-            os_unfair_lock_unlock(&_unfairLock);
-        } else {
-            pthread_mutex_lock(&_safeThreadDictionaryMutex);
-            copyInstance = [_dict copy];
-            pthread_mutex_unlock(&_safeThreadDictionaryMutex);
-        }
+        pthread_mutex_lock(&_safeThreadDictionaryMutex);
+        copyInstance = [_dict copy];
+        pthread_mutex_unlock(&_safeThreadDictionaryMutex);
     }
     
     return copyInstance;


### PR DESCRIPTION
try to resolve the crash of  dyld_stub_binder

```
2 libdyld.dylib 0x0000000183144ba0 dyld_stub_binder :60 (in libdyld.dylib)
3 app 0x00000001013742b8 -[WXThreadSafeMutableDictionary setObject:forKey:] WXThreadSafeMutableDictionary.m:208 (in app)
4 app 0x0000000101420cb0 +[WXMonitor performancePoint:willStartWithInstance:] WXMonitor.m:47 (in app)
5 app 0x0000000101404bb8 +[WXSDKEngine initSDKEnvironment:] WXSDKEngine.m:232 (in app)
6 app 0x0000000101404b48 +[WXSDKEngine initSDKEnvironment] WXSDKEngine.m:226 (in app)

```

Bug: 286
