### PR TITLE
*[Android] box-shadow size should cover padding and border

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXVContainer.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXVContainer.java
@@ -29,11 +29,13 @@ import android.util.Pair;
 import android.view.Menu;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
 
 import com.taobao.weex.WXSDKInstance;
 import com.taobao.weex.annotation.JSMethod;
 import com.taobao.weex.common.Constants;
 import com.taobao.weex.dom.WXDomObject;
+import com.taobao.weex.dom.flex.Spacing;
 import com.taobao.weex.ui.view.WXImageView;
 import com.taobao.weex.utils.WXLogUtils;
 import com.taobao.weex.utils.WXUtils;
@@ -596,7 +598,20 @@ public abstract class WXVContainer<T extends ViewGroup> extends WXComponent<T> {
         if (mBoxShadowHost == null) {
           mBoxShadowHost = new BoxShadowHost(getContext());
           WXViewUtils.setBackGround(mBoxShadowHost, null);
-          mBoxShadowHost.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+
+          Spacing padding = this.getDomObject().getPadding();
+          Spacing border = this.getDomObject().getBorder();
+
+          int left = (int) (padding.get(Spacing.LEFT) + border.get(Spacing.LEFT));
+          int top = (int) (padding.get(Spacing.TOP) + border.get(Spacing.TOP));
+          int right = (int) (padding.get(Spacing.RIGHT) + border.get(Spacing.RIGHT));
+          int bottom = (int) (padding.get(Spacing.BOTTOM) + border.get(Spacing.BOTTOM));
+
+          ViewGroup.MarginLayoutParams layoutParams = new ViewGroup.MarginLayoutParams(hostView.getLayoutParams()) ;
+          layoutParams.setMargins(-left, -top, -right, -bottom);
+
+          mBoxShadowHost.setLayoutParams(layoutParams);
+
           hostView.addView(mBoxShadowHost);
         }
         hostView.removeView(mBoxShadowHost);

--- a/android/sdk/src/main/java/com/taobao/weex/utils/BoxShadowUtil.java
+++ b/android/sdk/src/main/java/com/taobao/weex/utils/BoxShadowUtil.java
@@ -65,12 +65,12 @@ import java.util.regex.Pattern;
 
 public class BoxShadowUtil {
   private static final String TAG = "BoxShadowUtil";
-  private static boolean sBoxShadowEnabled = false /*disable box-shadow temporary*/;
+  private static boolean sBoxShadowEnabled = true /*disable box-shadow temporary*/;
 
   private static Pattern sColorPattern;
 
   public static void setBoxShadowEnabled(boolean enabled) {
-    //sBoxShadowEnabled = enabled;
+    sBoxShadowEnabled = enabled;
     WXLogUtils.w(TAG, "Switch box-shadow status: " + enabled);
   }
 
@@ -194,6 +194,8 @@ public class BoxShadowUtil {
   private static void setNormalBoxShadow(View target, List<BoxShadowOptions> options, float quality, float[] radii) {
     int h = target.getHeight();
     int w = target.getWidth();
+
+    ViewGroup.LayoutParams p = target.getLayoutParams();
 
     if (h == 0 || w == 0) {
       Log.w(TAG, "Target view is invisible, ignore set shadow.");

--- a/test/pages/css/border.vue
+++ b/test/pages/css/border.vue
@@ -53,6 +53,7 @@
         <text class="boxShadow1"></text>
         <text class="boxShadow2"></text>
         <text class="boxShadow3"></text>
+        <text class="boxShadow4"></text>
         <text test-id="test-text">box shadow</text>
     </div>
     <div class="container">
@@ -304,6 +305,14 @@
   box-shadow: 0px 0px 1px 1px rgba(0,0,0,0.06);
   border-bottom-right-radius: 50px;
   margin:30px;
+}
+.boxShadow4 {
+  width: 100px;
+  height: 45px;
+  background-color: red;
+  box-shadow: 0px 0px 10px 0px green;
+  padding: 20px;
+  border-width: 5px;
 }
 
 .circle {


### PR DESCRIPTION
Hi ~ I found some problem in Android side when i use box-shadow. Look that:

**In H5 side:**
<img  src="https://user-images.githubusercontent.com/29728294/38844686-3be92bca-4227-11e8-938e-6396175760bd.png" width="350px" />

**In iOS side:**
<img src="https://user-images.githubusercontent.com/29728294/38844783-9bc3e1c0-4227-11e8-8120-15e9849d59ac.jpeg" width="350px" />

**In Android side:**
<img src="https://user-images.githubusercontent.com/29728294/38844867-d6980cc2-4227-11e8-8a72-c2add9527b7f.png" width="350px" />

Now, you see the bug.
The box-shadow style should cover box's padding and border when render the shadow. But Android side is different from the iOS and H5 side.
These change fix this Bug.

This is a test case. [android-bugfix-boxshadow-testcase](http://dotwe.org/vue/4ab90f1cae7c5313c31ab4316b306a6e)
