### PR TITLE
【iOS】Resolve WXLogLevel naming and conflict in WechatSDK，Rename to WeexLogLevel.

### DIFF
--- a/ios/playground/WeexDemo.xcodeproj/project.pbxproj
+++ b/ios/playground/WeexDemo.xcodeproj/project.pbxproj
@@ -534,16 +534,22 @@
 				"${PODS_ROOT}/ATSDK-Weex/ATSDK.framework/Versions/A/Resources/ATSDK.bundle",
 				"${PODS_ROOT}/ATSDK-Weex/ATSDK.framework/Versions/A/Resources/en.lproj",
 				"${PODS_ROOT}/ATSDK-Weex/ATSDK.framework/Versions/A/Resources/zh-Hans.lproj",
-				"${PODS_ROOT}/GCanvas/GCanvas.framework/default.glsl",
-				"${PODS_ROOT}/GCanvas/GCanvas.framework/grad.glsl",
-				"${PODS_ROOT}/GCanvas/GCanvas.framework/pattern.glsl",
-				"${PODS_ROOT}/GCanvas/GCanvas.framework/radiation.glsl",
 				"${PODS_ROOT}/../../../pre-build/native-bundle-main.js",
+				"${PODS_ROOT}/../../../pre-build/weex-main-jsfm.js",
+				"${PODS_ROOT}/../../../pre-build/weex-polyfill.js",
+				"${PODS_ROOT}/../../../pre-build/weex-rax-api.js",
 				"${PODS_ROOT}/../../sdk/WeexSDK/Resources/wx_load_error@3x.png",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ATSDK.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/en.lproj",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/zh-Hans.lproj",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/native-bundle-main.js",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/weex-main-jsfm.js",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/weex-polyfill.js",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/weex-rax-api.js",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/wx_load_error@3x.png",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -593,16 +599,22 @@
 				"${PODS_ROOT}/ATSDK-Weex/ATSDK.framework/Versions/A/Resources/ATSDK.bundle",
 				"${PODS_ROOT}/ATSDK-Weex/ATSDK.framework/Versions/A/Resources/en.lproj",
 				"${PODS_ROOT}/ATSDK-Weex/ATSDK.framework/Versions/A/Resources/zh-Hans.lproj",
-				"${PODS_ROOT}/GCanvas/GCanvas.framework/default.glsl",
-				"${PODS_ROOT}/GCanvas/GCanvas.framework/grad.glsl",
-				"${PODS_ROOT}/GCanvas/GCanvas.framework/pattern.glsl",
-				"${PODS_ROOT}/GCanvas/GCanvas.framework/radiation.glsl",
 				"${PODS_ROOT}/../../../pre-build/native-bundle-main.js",
+				"${PODS_ROOT}/../../../pre-build/weex-main-jsfm.js",
+				"${PODS_ROOT}/../../../pre-build/weex-polyfill.js",
+				"${PODS_ROOT}/../../../pre-build/weex-rax-api.js",
 				"${PODS_ROOT}/../../sdk/WeexSDK/Resources/wx_load_error@3x.png",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ATSDK.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/en.lproj",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/zh-Hans.lproj",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/native-bundle-main.js",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/weex-main-jsfm.js",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/weex-polyfill.js",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/weex-rax-api.js",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/wx_load_error@3x.png",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/playground/WeexDemo.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/playground/WeexDemo.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/playground/WeexDemo/AppDelegate.m
+++ b/ios/playground/WeexDemo/AppDelegate.m
@@ -132,14 +132,14 @@
 #ifdef DEBUG
     [self atAddPlugin];
     [WXDebugTool setDebug:YES];
-    [WXLog setLogLevel:WXLogLevelLog];
+    [WXLog setLogLevel:WeexLogLevelLog];
     
     #ifndef UITEST
         [[ATManager shareInstance] show];
     #endif
 #else
     [WXDebugTool setDebug:NO];
-    [WXLog setLogLevel:WXLogLevelError];
+    [WXLog setLogLevel:WeexLogLevelError];
 #endif
 }
 

--- a/ios/sdk/WeexSDK/Sources/Component/RecycleList/WXCellSlotComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/RecycleList/WXCellSlotComponent.m
@@ -77,7 +77,7 @@
     
     if ([self needsLayout]) {
         layoutNode(self.cssNode, CSS_UNDEFINED, CSS_UNDEFINED, CSS_DIRECTION_INHERIT);
-        if ([WXLog logLevel] >= WXLogLevelDebug) {
+        if ([WXLog logLevel] >= WeexLogLevelDebug) {
             print_css_node(self.cssNode, CSS_PRINT_LAYOUT | CSS_PRINT_STYLE | CSS_PRINT_CHILDREN);
         }
     }

--- a/ios/sdk/WeexSDK/Sources/Component/WXCellComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXCellComponent.m
@@ -131,7 +131,7 @@
     
     if ([self needsLayout]) {
         layoutNode(self.cssNode, CSS_UNDEFINED, CSS_UNDEFINED, CSS_DIRECTION_INHERIT);
-        if ([WXLog logLevel] >= WXLogLevelDebug) {
+        if ([WXLog logLevel] >= WeexLogLevelDebug) {
             print_css_node(self.cssNode, CSS_PRINT_LAYOUT | CSS_PRINT_STYLE | CSS_PRINT_CHILDREN);
         }
     }

--- a/ios/sdk/WeexSDK/Sources/Component/WXHeaderComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXHeaderComponent.m
@@ -76,7 +76,7 @@
     
     if ([self needsLayout]) {
         layoutNode(self.cssNode, CSS_UNDEFINED, CSS_UNDEFINED, CSS_DIRECTION_INHERIT);
-        if ([WXLog logLevel] >= WXLogLevelDebug) {
+        if ([WXLog logLevel] >= WeexLogLevelDebug) {
             print_css_node(self.cssNode, CSS_PRINT_LAYOUT | CSS_PRINT_STYLE | CSS_PRINT_CHILDREN);
         }
     }

--- a/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.m
@@ -849,7 +849,7 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
         _scrollerCSSNode->layout.dimensions[CSS_HEIGHT] = CSS_UNDEFINED;
         
         layoutNode(_scrollerCSSNode, CSS_UNDEFINED, CSS_UNDEFINED, CSS_DIRECTION_INHERIT);
-        if ([WXLog logLevel] >= WXLogLevelDebug) {
+        if ([WXLog logLevel] >= WeexLogLevelDebug) {
             print_css_node(_scrollerCSSNode, CSS_PRINT_LAYOUT | CSS_PRINT_STYLE | CSS_PRINT_CHILDREN);
         }
         CGSize size = {

--- a/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.m
@@ -818,7 +818,7 @@ static css_node_t * rootNodeGetChild(void *context, int i)
     layoutNode(_rootCSSNode, _rootCSSNode->style.dimensions[CSS_WIDTH], _rootCSSNode->style.dimensions[CSS_HEIGHT], CSS_DIRECTION_INHERIT);
     
     if ([_rootComponent needsLayout]) {
-        if ([WXLog logLevel] >= WXLogLevelDebug) {
+        if ([WXLog logLevel] >= WeexLogLevelDebug) {
             print_css_node(_rootCSSNode, CSS_PRINT_LAYOUT | CSS_PRINT_STYLE | CSS_PRINT_CHILDREN);
         }
     }

--- a/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
+++ b/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
@@ -256,7 +256,7 @@ typedef enum : NSUInteger {
     WX_MONITOR_INSTANCE_PERF_START(WXPTAllRender, self);
     
     NSMutableDictionary *dictionary = [_options mutableCopy];
-    if ([WXLog logLevel] >= WXLogLevelLog) {
+    if ([WXLog logLevel] >= WeexLogLevelLog) {
         dictionary[@"debug"] = @(YES);
     }
     

--- a/ios/sdk/WeexSDK/Sources/Monitor/WXMonitor.m
+++ b/ios/sdk/WeexSDK/Sources/Monitor/WXMonitor.m
@@ -220,7 +220,7 @@ static WXThreadSafeMutableDictionary *globalPerformanceDict;
 
 + (void)printPerformance:(NSDictionary *)commitDict
 {
-    if ([WXLog logLevel] < WXLogLevelLog) {
+    if ([WXLog logLevel] < WeexLogLevelLog) {
         return;
     }
     

--- a/ios/sdk/WeexSDK/Sources/Utility/WXLog.h
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXLog.h
@@ -30,41 +30,41 @@ typedef NS_ENUM(NSInteger, WXLogFlag) {
 /**
  *  Use Log levels to filter logs.
  */
-typedef NS_ENUM(NSUInteger, WXLogLevel){
+typedef NS_ENUM(NSUInteger, WeexLogLevel){
     /**
      *  No logs
      */
-    WXLogLevelOff       = 0,
+    WeexLogLevelOff       = 0,
     
     /**
      *  Error only
      */
-    WXLogLevelError     = WXLogFlagError,
+    WeexLogLevelError     = WXLogFlagError,
     
     /**
      *  Error and warning
      */
-    WXLogLevelWarning   = WXLogLevelError | WXLogFlagWarning,
+    WeexLogLevelWarning   = WeexLogLevelError | WXLogFlagWarning,
     
     /**
      *  Error, warning and info
      */
-    WXLogLevelInfo      = WXLogLevelWarning | WXLogFlagInfo,
+    WeexLogLevelInfo      = WeexLogLevelWarning | WXLogFlagInfo,
     
     /**
      *  Log, warning info
      */
-    WXLogLevelLog       = WXLogFlagLog | WXLogLevelInfo,
+    WeexLogLevelLog       = WXLogFlagLog | WeexLogLevelInfo,
     
     /**
      *  Error, warning, info and debug logs
      */
-    WXLogLevelDebug     = WXLogLevelLog | WXLogFlagDebug,
+    WeexLogLevelDebug     = WeexLogLevelLog | WXLogFlagDebug,
     
     /**
      *  All
      */
-    WXLogLevelAll       = NSUIntegerMax
+    WeexLogLevelAll       = NSUIntegerMax
 };
 
 /**
@@ -77,7 +77,7 @@ typedef NS_ENUM(NSUInteger, WXLogLevel){
 /**
  * External log level.
  */
-- (WXLogLevel)logLevel;
+- (WeexLogLevel)logLevel;
 
 - (void)log:(WXLogFlag)flag message:(NSString *)message;
 
@@ -85,9 +85,9 @@ typedef NS_ENUM(NSUInteger, WXLogLevel){
 
 @interface WXLog : NSObject
 
-+ (WXLogLevel)logLevel;
++ (WeexLogLevel)logLevel;
 
-+ (void)setLogLevel:(WXLogLevel)level;
++ (void)setLogLevel:(WeexLogLevel)level;
 
 + (NSString *)logLevelString;
 

--- a/ios/sdk/WeexSDK/Sources/Utility/WXLog.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXLog.m
@@ -47,16 +47,16 @@
 // Insert the ESCAPE_SEQ into your string, followed by ";"
 
 #ifdef DEBUG
-static const WXLogLevel defaultLogLevel = WXLogLevelLog;
+static const WeexLogLevel defaultLogLevel = WeexLogLevelLog;
 #else
-static const WXLogLevel defaultLogLevel = WXLogLevelWarning;
+static const WeexLogLevel defaultLogLevel = WeexLogLevelWarning;
 #endif
 
 static id<WXLogProtocol> _externalLog;
 
 @implementation WXLog
 {
-    WXLogLevel _logLevel;
+    WeexLogLevel _logLevel;
 }
 
 + (instancetype)sharedInstance
@@ -71,7 +71,7 @@ static id<WXLogProtocol> _externalLog;
 }
 
 
-+ (void)setLogLevel:(WXLogLevel)level
++ (void)setLogLevel:(WeexLogLevel)level
 {
     if (((WXLog*)[self sharedInstance])->_logLevel != level) {
         ((WXLog*)[self sharedInstance])->_logLevel = level;
@@ -88,7 +88,7 @@ static id<WXLogProtocol> _externalLog;
 #pragma clang diagnostic pop
 }
 
-+ (WXLogLevel)logLevel
++ (WeexLogLevel)logLevel
 {
     return ((WXLog*)[self sharedInstance])->_logLevel;
 }
@@ -97,13 +97,13 @@ static id<WXLogProtocol> _externalLog;
 {
     NSDictionary *logLevelEnumToString =
     @{
-      @(WXLogLevelOff) : @"off",
-      @(WXLogLevelError) : @"error",
-      @(WXLogLevelWarning) : @"warn",
-      @(WXLogLevelInfo) : @"info",
-      @(WXLogLevelLog) : @"log",
-      @(WXLogLevelDebug) : @"debug",
-      @(WXLogLevelAll) : @"debug"
+      @(WeexLogLevelOff) : @"off",
+      @(WeexLogLevelError) : @"error",
+      @(WeexLogLevelWarning) : @"warn",
+      @(WeexLogLevelInfo) : @"info",
+      @(WeexLogLevelLog) : @"log",
+      @(WeexLogLevelDebug) : @"debug",
+      @(WeexLogLevelAll) : @"debug"
       };
     return [logLevelEnumToString objectForKey:@([self logLevel])];
 }
@@ -112,12 +112,12 @@ static id<WXLogProtocol> _externalLog;
 {
     NSDictionary *logLevelStringToEnum =
     @{
-      @"all" : @(WXLogLevelAll),
-      @"error" : @(WXLogLevelError),
-      @"warn" : @(WXLogLevelWarning),
-      @"info" : @(WXLogLevelInfo),
-      @"debug" : @(WXLogLevelDebug),
-      @"log" : @(WXLogLevelLog)
+      @"all" : @(WeexLogLevelAll),
+      @"error" : @(WeexLogLevelError),
+      @"warn" : @(WeexLogLevelWarning),
+      @"info" : @(WeexLogLevelInfo),
+      @"debug" : @(WeexLogLevelDebug),
+      @"log" : @(WeexLogLevelLog)
     };
     
     [self setLogLevel:[logLevelStringToEnum[levelString] unsignedIntegerValue]];


### PR DESCRIPTION
 Resolve WXLogLevel naming and conflict in WechatSDK，Rename to WeexLogLevel.