### PR TITLE
[jsfm] Support to build a standalone polyfill package

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -74,6 +74,7 @@ async function build (name) {
     case 'jsfm':
     case 'native': pkgName = 'weex-js-framework'; break
     case 'env': pkgName = 'weex-env'; break
+    case 'polyfill': pkgName = 'weex-polyfill'; break
     case 'vue': pkgName = 'weex-vue'; break
     case 'rax': pkgName = 'weex-rax'; break
     case 'runtime': pkgName = 'weex-js-runtime'; break

--- a/build/config.js
+++ b/build/config.js
@@ -54,6 +54,13 @@ const configs = {
         + `var global = this; var process = {env:{}};`
     }
   },
+  'weex-polyfill': {
+    input: absolute('runtime/entries/polyfill.js'),
+    output: {
+      format: 'iife',
+      file: absolute('pre-build/weex-polyfill')
+    }
+  },
   'weex-vue': {
     input: absolute('runtime/entries/vue.js'),
     output: {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "build:jsfm": "node build/build.js jsfm",
     "build:env": "WEEX_FREEZE=true node build/build.js env",
+    "build:polyfill": "node build/build.js polyfill",
     "build:native": "node build/build.js native",
     "build:vue": "node build/build.js vue",
     "build:rax": "node build/build.js rax",

--- a/runtime/entries/polyfill.js
+++ b/runtime/entries/polyfill.js
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import '../shared/polyfill/arrayFrom'
+import '../shared/polyfill/objectAssign'
+import '../shared/polyfill/objectSetPrototypeOf'
+
+// import promise hack and polyfills
+import '../shared/polyfill/promise'
+import 'core-js/modules/es6.object.to-string'
+import 'core-js/modules/es6.string.iterator'
+import 'core-js/modules/web.dom.iterable'
+import 'core-js/modules/es6.promise'


### PR DESCRIPTION
Build a standalone polyfill package which can be used in some outdated versions of iOS.

The `weex-polyfill` package contains:

+ `Array.from`
+ `Object.assign`
+ `Object.setPrototypeOf`
+ `Promise`