### PR TITLE
[WEEX-325][android] Some MeiZhu Mobole throw NoClassDefFoundError: android/support/design/widget/AppBarLayout$OnOffsetChangedListener

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/SimpleComponentHolder.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/SimpleComponentHolder.java
@@ -172,6 +172,8 @@ public class SimpleComponentHolder implements IFComponentHolder{
     }catch (IndexOutOfBoundsException e){
       e.printStackTrace();
       //ignore: getMethods may throw this
+    }catch (Exception e){ // in meizhu mobile, throw class not found exception in getMethods
+      WXLogUtils.e(TAG, e);
     }
     return new Pair<>(methods,mInvokers);
   }


### PR DESCRIPTION
weex_enchane throw exception, weex should catch the exception and not  effect other component and weex sdk.  [WEEX-325][android] Some MeiZhu Mobole throw NoClassDefFoundError: android/support/design/widget/AppBarLayout$OnOffsetChangedListener