### PR TITLE
[iOS]bugfix: toast should display on weex window

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Module/WXModalUIModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXModalUIModule.m
@@ -129,7 +129,7 @@ static const CGFloat WXToastDefaultPadding = 30.0;
 - (void)toast:(NSString *)message duration:(double)duration
 {
     WXAssertMainThread();
-    UIView *superView =  [[UIApplication sharedApplication] keyWindow];
+    UIView *superView = self.weexInstance.rootView.window;
     if (!superView) {
         superView =  self.weexInstance.rootView;
     }


### PR DESCRIPTION
bugfix: weex toast should display on the window that contain weex root view