### PR TITLE
[WEEX-337] [jsfm]  enable weex.supports return correctly when component/module name contains '-'

### DIFF
--- a/runtime/api/WeexInstance.js
+++ b/runtime/api/WeexInstance.js
@@ -114,7 +114,7 @@ export default class WeexInstance {
   supports (condition) {
     if (typeof condition !== 'string') return null
 
-    const res = condition.match(/^@(\w+)\/(\w+)(\.(\w+))?$/i)
+    const res = condition.match(/^@(\w+)\/([\w-]+)(\.(\w+))?$/i)
     if (res) {
       const type = res[1]
       const name = res[2]


### PR DESCRIPTION
weex.supports can't distinguish component or module when their name contains '-', 
and it always return null.

example: http://dotwe.org/vue/26b73776ae3e34c4335491ce40e89e57

