### PR TITLE
[WEEX-340][iOS]fix the window problem where weex toast is displayed

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Module/WXModalUIModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXModalUIModule.m
@@ -129,7 +129,7 @@ static const CGFloat WXToastDefaultPadding = 30.0;
 - (void)toast:(NSString *)message duration:(double)duration
 {
     WXAssertMainThread();
-    UIView *superView =  [[UIApplication sharedApplication] keyWindow];
+    UIView *superView = self.weexInstance.rootView.window;
     if (!superView) {
         superView =  self.weexInstance.rootView;
     }


### PR DESCRIPTION
Weex toast should be displayed in the window where weex is located. 
If the window does not exist, it is displayed on the weex root view.