### PR TITLE
[WEEX-343] [iOS] Failure of "scaleY" on animationModule

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Module/WXAnimationModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXAnimationModule.m
@@ -245,7 +245,7 @@ WX_EXPORT_METHOD(@selector(transition:args:callback:))
                 WXAnimationInfo *newInfo = [info copy];
                 newInfo.propertyName = @"transform.scale.y";
                 newInfo.fromValue = @(oldTransform.scaleY);
-                newInfo.toValue = @(wxTransform.scaleX);
+                newInfo.toValue = @(wxTransform.scaleY);
                 [infos addObject:newInfo];
             }
             


### PR DESCRIPTION
Because of a very old mistake, when parsing the transform property, the error scaleY is parsed
You can see demo in http://dotwe.org/vue/95a7067fde100e6b8f5219d4bf1913c3

