### PR TITLE
[WEEX-340][iOS]Fix the window problem where weex toast is displayed

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Module/WXModalUIModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXModalUIModule.m
@@ -129,7 +129,7 @@ static const CGFloat WXToastDefaultPadding = 30.0;
 - (void)toast:(NSString *)message duration:(double)duration
 {
     WXAssertMainThread();
-    UIView *superView =  [[UIApplication sharedApplication] keyWindow];
+    UIView *superView = self.weexInstance.rootView.window;
     if (!superView) {
         superView =  self.weexInstance.rootView;
     }


### PR DESCRIPTION
Because the APP's keyWindow usually change with the business, weex's toast view should be displayed in the window where weex is located. If the window does not exist, it should displayed on the weex root view.

U can check this [EXAMPLE](http://dotwe.org/vue/3ce829a89653d651aeadf145af3f98a0)