### PR TITLE
[WEEX-350][iOS] fix anim crash caused by problem that [WXConvert CGFl…

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.mm
+++ b/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.mm
@@ -540,7 +540,7 @@ do {\
 }
 
 -(CGFloat)judgePropValuePropValue:(NSString *)propValue defaultValue:(CGFloat)defaultValue{
-    CGFloat convertValue = (CGFloat)[WXConvert WXPixelType:propValue scaleFactor:self.weexInstance.pixelScaleFactor];
+    CGFloat convertValue = (CGFloat)[WXConvert WXFlexPixelType:propValue scaleFactor:self.weexInstance.pixelScaleFactor];
     if (!isnan(convertValue)) {
         return convertValue;
     }

--- a/ios/sdk/WeexSDK/Sources/Utility/WXConvert.h
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXConvert.h
@@ -28,7 +28,21 @@
 @interface WXConvert : NSObject
 
 + (BOOL)BOOL:(id)value;
+
+/**
+ *  @abstract       convert value to CGFloat value
+ *  @param value    value
+ *  @return         CGFloat value
+ */
 + (CGFloat)CGFloat:(id)value;
+
+/**
+ *  @abstract       convert value to CGFloat value, notice that it will return nan if input value is unsupported
+ *  @param value    value
+ *  @return         CGFloat value or nan(unsupported input)
+ */
++ (CGFloat)flexCGFloat:(id)value;
+
 + (NSUInteger)NSUInteger:(id)value;
 + (NSInteger)NSInteger:(id)value;
 + (NSString *)NSString:(id)value;
@@ -39,6 +53,8 @@
 typedef CGFloat WXPixelType;
 // @parameter scaleFactor: please use weexInstance's pixelScaleFactor property
 + (WXPixelType)WXPixelType:(id)value scaleFactor:(CGFloat)scaleFactor;
+// WXPixelType that use flexCGFloat to convert
++ (WXPixelType)WXFlexPixelType:(id)value scaleFactor:(CGFloat)scaleFactor;
 
 + (css_direction_t)css_direction_t:(id)value;
 + (css_flex_direction_t)css_flex_direction_t:(id)value;

--- a/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXConvert.m
@@ -63,6 +63,25 @@ WX_NUMBER_CONVERT(NSUInteger, unsignedIntegerValue)
 {
     if ([value isKindOfClass:[NSString class]]) {
         NSString *valueString = (NSString *)value;
+        if ([valueString hasSuffix:@"px"] || [valueString hasSuffix:@"wx"]) {
+            valueString = [valueString substringToIndex:(valueString.length - 2)];
+        }
+        if ([value hasPrefix:@"env(safe-area-inset-"] &&[value hasSuffix:@")"]){
+            NSUInteger start = [value rangeOfString:@"env(safe-area-inset-"].location +@"env(safe-area-inset-".length;
+            NSUInteger end = [value rangeOfString:@")" options:NSBackwardsSearch].location;
+            value = [value substringWithRange:NSMakeRange(start, end-start)];
+            return [self safeAreaInset:value];
+        }
+        return [valueString doubleValue];
+    }
+    
+    return [self double:value];
+}
+
++ (CGFloat)flexCGFloat:(id)value
+{
+    if ([value isKindOfClass:[NSString class]]) {
+        NSString *valueString = (NSString *)value;
         if (valueString.length <=0) {
             return NAN;
         }
@@ -81,7 +100,6 @@ WX_NUMBER_CONVERT(NSUInteger, unsignedIntegerValue)
         }
         return [valueString doubleValue];
     }
-    
     return [self double:value];
 }
 
@@ -160,6 +178,16 @@ WX_NUMBER_CONVERT(NSUInteger, unsignedIntegerValue)
 + (WXPixelType)WXPixelType:(id)value scaleFactor:(CGFloat)scaleFactor
 {
     CGFloat pixel = [self CGFloat:value];
+    
+    if ([value isKindOfClass:[NSString class]] && ([value hasSuffix:@"wx"]|| [value hasPrefix:@"env(safe-area-inset-"])) {
+        return pixel;
+    }
+    return pixel * scaleFactor;
+}
+
++ (WXPixelType)WXFlexPixelType:(id)value scaleFactor:(CGFloat)scaleFactor
+{
+    CGFloat pixel = [self flexCGFloat:value];
     
     if ([value isKindOfClass:[NSString class]] && ([value hasSuffix:@"wx"]|| [value hasPrefix:@"env(safe-area-inset-"])) {
         return pixel;


### PR DESCRIPTION
[WXConvert CGFloat:] when input value is unsupported,it will return nan value.in some case,anim operation will crash.therefore, build a new method to distinguish these two usages.