### PR TITLE
[WEEX-360] [Android] Fix crash when reinit framework

### DIFF
--- a/weex_core/Source/android/jsengine/multiprocess/WeexProxy.h
+++ b/weex_core/Source/android/jsengine/multiprocess/WeexProxy.h
@@ -53,8 +53,8 @@ public:
     initFromParam(JNIEnv *env, jstring script, jobject params, IPCSerializer *serializer);
 
     static jint
-    initFrameworkInSingleProcess(JNIEnv *env, jstring script, std::vector<INIT_FRAMEWORK_PARAMS *> initFrameworkParams);
-    static jint initFrameworkInMultiProcess(JNIEnv *env, jstring script, IPCSerializer *serializer);
+    initFrameworkInSingleProcess(JNIEnv *env, jstring script, jobject params);
+    static jint initFrameworkInMultiProcess(JNIEnv *env, jstring script, jobject params);
 
     static const char *getCacheDir(JNIEnv *env);
 


### PR DESCRIPTION
serializer will be freed after framework inited finished.
So if we use it for re initialize. Will cause null ptr.

Bug: WEEX-360

JIRA  https://issues.apache.org/jira/browse/WEEX-360