### PR TITLE
[WEEX-373][iOS] try to fix the issue about _remove_assocations

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Bridge/WXJSCoreBridge.m
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXJSCoreBridge.m
@@ -109,6 +109,11 @@
     return self;
 }
 
+- (void)dealloc
+{
+    _jsContext.instanceId = nil;
+}
+
 - (void)setJSContext:(JSContext *)context
 {
     _jsContext = context;


### PR DESCRIPTION
 As the the crash stack shows app crash during the deallocating of remove_assocation in JSContext object,
so we try to remove the association manually.

0 libobjc.A.dylib 0x00000001916318d8 _object_remove_assocations :260 (in libobjc.A.dylib)
1 libobjc.A.dylib 0x000000019162c340 _objc_destructInstance :104 (in libobjc.A.dylib)
2 libobjc.A.dylib 0x000000019162c398 _object_dispose :28 (in libobjc.A.dylib)
3 0x00000001018d5894 NSObjectLifeCycleDealloc NSObjectLifeCycle.m:104 (in)
4 JavaScriptCore 0x00000001971876ec -[JSContext dealloc] :196 (in JavaScriptCore)
5 libobjc.A.dylib 0x000000019163e134 (anonymous namespace)::AutoreleasePoolPage::pop(void*) :836 (in libobjc.A.dylib)
6 CoreFoundation 0x0000000192a9ab28 _CFAutoreleasePoolPop :28 (in CoreFoundation)
7 Foundation 0x00000001936b35c0 __NSThreadPerformPerform :520 (in Foundation)

Bug:373