### PR TITLE
Update WXRecyclerUpdateController.m

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/Recycler/WXRecyclerUpdateController.m
+++ b/ios/sdk/WeexSDK/Sources/Component/Recycler/WXRecyclerUpdateController.m
@@ -146,6 +146,7 @@
         [self.delegate updateController:self willPerformUpdateWithNewData:newData];
         [UIView setAnimationsEnabled:NO];
         WXLogDebug(@"UICollectionView update:%@", diffResult);
+        if(!diffResult.hasChanges) { return ; }
         [self applyUpdate:diffResult toCollectionView:self.collectionView];
     } copy];
     


### PR DESCRIPTION
Fix one crash.

```
*** -[__NSDictionaryM setObject:forKey:]: key cannot be nil
```

This exception will be yelled at line 167.

