### PR TITLE
[WEEX-395][Android] add more user tracks to track init framework

### DIFF
--- a/weex_core/Source/android/base/string/string_utils.h
+++ b/weex_core/Source/android/base/string/string_utils.h
@@ -52,9 +52,13 @@ static inline std::string jString2Str(JNIEnv *env, const jstring &jstr) {
   env->DeleteLocalRef(strencode);
   env->DeleteLocalRef(barr);
 
-  std::string stemp(rtn);
-  free(rtn);
-  return stemp;
+  if(rtn != NULL) {
+    std::string stemp(rtn);
+    free(rtn);
+    return stemp;
+  } else {
+    return "";
+  }
 }
 
 static inline std::string jString2StrFast(JNIEnv *env, const jstring &jstr){
@@ -72,14 +76,17 @@ static std::string jByteArray2Str(JNIEnv *env, jbyteArray barr) {
     rtn = (char *) malloc(alen + 1);
     memcpy(rtn, ba, alen);
     rtn[alen] = 0;
-  } else {
-    return "";
   }
   env->ReleaseByteArrayElements(barr, ba, 0);
 
-  std::string stemp(rtn);
-  free(rtn);
-  return stemp;
+  if(rtn != NULL){
+    std::string stemp(rtn);
+    free(rtn);
+    return stemp;
+  } else {
+    return "";
+  }
+
 }
 
 static inline jbyteArray newJByteArray(JNIEnv *env, const char* pat) {

--- a/weex_core/Source/android/jsengine/multiprocess/WeexProxy.cpp
+++ b/weex_core/Source/android/jsengine/multiprocess/WeexProxy.cpp
@@ -518,7 +518,7 @@ namespace WeexCore {
             soPath += "/libweexjss.so";
             if (access(soPath.c_str(), 00) != 0) {
                 LOGE("so path: %s is not exsist", soPath.c_str());
-                //reportNativeInitStatus("-1004", error);
+                reportNativeInitStatus("-1004", error);
                 //return false;
                 //use libweexjss.so directly
                 soPath = "libweexjss.so";
@@ -531,7 +531,7 @@ namespace WeexCore {
         if (!handle) {
             const char *error = dlerror();
             LOGE("load libweexjss.so failed,error=%s\n", error);
-//        reportNativeInitStatus("-1005", error);
+            reportNativeInitStatus("-1005", error);
             // try again use current path
             dlclose(handle);
             return false;
@@ -545,7 +545,7 @@ namespace WeexCore {
         if (!initMethod) {
             const char *error = dlerror();
             LOGE("load External_InitFrameWork failed,error=%s\n", error);
-//        reportNativeInitStatus("-1006", error);
+            reportNativeInitStatus("-1006", error);
             dlclose(handle);
             return false;
         }
@@ -565,7 +565,7 @@ namespace WeexCore {
             dlclose(handle);
             free(pFunctions);
             free(js_server_api_functions);
-            //reportNativeInitStatus("-1007", "Init Functions failed");
+            reportNativeInitStatus("-1007", "Init Functions failed");
             return false;
         }
     }
@@ -716,8 +716,12 @@ namespace WeexCore {
                     serializer->add(c_value_chars, c_value_len);
                     initFrameworkParams.push_back(
                             genInitFrameworkParams(c_key_chars, c_value_chars));
-                    WXCoreEnvironment::getInstance()->AddOption(jString2Str(env, jkey),
-                                                                jString2Str(env, jvalue));
+                    const std::string &key = jString2Str(env, jkey);
+                    if (key != "") {
+                        WXCoreEnvironment::getInstance()->AddOption(key,
+                                                                    jString2Str(env, jvalue));
+                    }
+
                 }
             }
             env->DeleteLocalRef(jobjArray);


### PR DESCRIPTION
    [WEEX-395][Android] add more user tracks to track init framework
    
    add more user tracks to track init framework,
    For example. we can track can't find libweexjss.so
    Fix NPE cause str may be null
    
    Bug: WEEX-395

https://issues.apache.org/jira/browse/WEEX-395
