### PR TITLE
[WEEX-413] [iOS] Fix when main thread parse transform cause deadlock

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXTransform.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTransform.m
@@ -23,6 +23,8 @@
 #import "WXUtility.h"
 #import "WXSDKInstance.h"
 #import "WXConvert.h"
+#import "WXSDKEngine.h"
+#import "WXConfigCenterProtocol.h"
 
 @interface WXTransform()
 
@@ -257,7 +259,18 @@
         SEL method = NSSelectorFromString([NSString stringWithFormat:@"parse%@:", [name capitalizedString]]);
         if ([self respondsToSelector:method]) {
             @try {
-                [self performSelectorOnMainThread:method withObject:value waitUntilDone:YES];
+                id<WXConfigCenterProtocol> configCenter = [WXSDKEngine handlerForProtocol:@protocol(WXConfigCenterProtocol)];
+                if ([configCenter respondsToSelector:@selector(configForKey:defaultValue:isDefault:)]) {
+                    BOOL parseTransformIfWaitUntilDone = [[configCenter configForKey:@"iOS_weex_ext_config.parseTransformIfWaitUntilDone" defaultValue:@(NO) isDefault:NULL] boolValue];
+                    if (parseTransformIfWaitUntilDone) {
+                        [self performSelectorOnMainThread:method withObject:value waitUntilDone:YES];
+                    }
+                    else{
+                        IMP imp = [self methodForSelector:method];
+                        void (*func)(id, SEL,NSArray *) = (void *)imp;
+                        func(self, method,value);
+                    }
+                }
             }
             @catch (NSException *exception) {
                 WXLogError(@"WXTransform exception:%@", [exception reason]);


### PR DESCRIPTION
The problem is because when parsing transform, the component thread wait until main thread finish its work with  main thread still waiting component thead work done.
You can try demo on this dotwe.http://dotwe.org/vue/caeb8e370f1ddd7d249263c153ea7694

