### PR TITLE
[WEEX-435][android] modify playground app camera runtime permission request behavior

### DIFF
--- a/android/playground/app/src/main/java/com/alibaba/weex/IndexActivity.java
+++ b/android/playground/app/src/main/java/com/alibaba/weex/IndexActivity.java
@@ -149,11 +149,14 @@ public class IndexActivity extends AbstractWeexActivity {
   @Override
   public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
     super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    if (requestCode == CAMERA_PERMISSION_REQUEST_CODE && grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-      startActivity(new Intent(this, CaptureActivity.class));
-    } else if (requestCode == WRITE_EXTERNAL_STORAGE_PERMISSION_REQUEST_CODE && grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-    } else {
-      Toast.makeText(this, "request camara permission fail!", Toast.LENGTH_SHORT).show();
+    if (requestCode == CAMERA_PERMISSION_REQUEST_CODE) {
+      if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+        startActivity(new Intent(this, CaptureActivity.class));
+      } else {
+        Toast.makeText(this, "request camara permission fail!", Toast.LENGTH_SHORT).show();
+      }
+    } else if (requestCode == WRITE_EXTERNAL_STORAGE_PERMISSION_REQUEST_CODE
+            && grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
     }
   }
 

--- a/android/playground/app/src/main/java/com/alibaba/weex/extend/module/WXEventModule.java
+++ b/android/playground/app/src/main/java/com/alibaba/weex/extend/module/WXEventModule.java
@@ -20,11 +20,14 @@ package com.alibaba.weex.extend.module;
 
 import android.Manifest;
 import android.app.Activity;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
+import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.widget.Toast;
 
@@ -57,8 +60,8 @@ public class WXEventModule extends WXModule {
     if ("weex://go/scan".equals(url)) {
       if (ContextCompat.checkSelfPermission(mWXSDKInstance.getContext(), Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
         if (ActivityCompat.shouldShowRequestPermissionRationale((Activity) mWXSDKInstance.getContext(), Manifest.permission.CAMERA)) {
-          Toast.makeText(mWXSDKInstance.getContext(), "Weex playground need the camera permission to scan QR code", Toast.LENGTH_SHORT).show();
-        } else {
+          showCameraPermissionRationale();
+        } else{
           ActivityCompat.requestPermissions((Activity) mWXSDKInstance.getContext(), new String[]{Manifest.permission.CAMERA}, CAMERA_PERMISSION_REQUEST_CODE);
         }
       } else {
@@ -89,6 +92,21 @@ public class WXEventModule extends WXModule {
       mWXSDKInstance.fireModuleEvent("event", this, params);
     }
   }
+
+  private void showCameraPermissionRationale() {
+    if (mWXSDKInstance.getContext() instanceof AppCompatActivity) {
+      AlertDialog.Builder builder = new AlertDialog.Builder(((AppCompatActivity) mWXSDKInstance.getContext()));
+      builder.setMessage("Weex playground need the camera permission to scan QR code");
+      builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+          ActivityCompat.requestPermissions((Activity) mWXSDKInstance.getContext(), new String[]{Manifest.permission.CAMERA}, CAMERA_PERMISSION_REQUEST_CODE);
+        }
+      });
+      builder.create().show();
+    }
+  }
+
   /*
    * a test method for macaca case, you can fire globalEvent when download finish、device shaked and so on.
    * @param event event name
@@ -108,9 +126,13 @@ public class WXEventModule extends WXModule {
 
   @Override
   public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-    super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    if (requestCode == CAMERA_PERMISSION_REQUEST_CODE && grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-      mWXSDKInstance.getContext().startActivity(new Intent(mWXSDKInstance.getContext(), CaptureActivity.class));
-    }
+      super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+      if (requestCode == CAMERA_PERMISSION_REQUEST_CODE) {
+          if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+              mWXSDKInstance.getContext().startActivity(new Intent(mWXSDKInstance.getContext(), CaptureActivity.class));
+          } else {
+              Toast.makeText(mWXSDKInstance.getContext(), "request camara permission fail!", Toast.LENGTH_SHORT).show();
+          }
+      }
   }
 }


### PR DESCRIPTION
For `ActivityCompat.shouldShowRequestPermissionRationale()`, it means your app should display a dialog or something else to explain why you are going to request this permission, and **try again to request the permission**, see https://developer.android.com/training/permissions/requesting and https://github.com/googlesamples/android-RuntimePermissionsBasic/blob/master/Application/src/main/java/com/example/android/basicpermissions/MainActivity.java#L124

For the original code, if the permission was **NOT** granted, the `ContextCompat.checkSelfPermission(mWXSDKInstance.getContext(), Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED` will always returns `true` and `ActivityCompat.shouldShowRequestPermissionRationale((Activity) mWXSDKInstance.getContext(), Manifest.permission.CAMERA)` did the same thing, which means If a user tap `扫描二维码`, the `Weex playground need the camera permission to scan QR code` toast will always show up without prompting a permission request dialog, users have to navigate to system app management and grant permission manually. If one user was not familiar with this mechanism,the Playground app will always be not able to scan code.

This patch fix can show a dialog to tell user that `Weex playground need the camera permission to scan QR code` **and then request this code immediately**, it will make the a system permission dialog alert and the user can now grant permission directly.