### PR TITLE
[WEEX-420][iOS] Try to resolve multithread crash during delete layoutNode

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.mm
+++ b/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.mm
@@ -247,9 +247,7 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
     [self.stickyArray removeAllObjects];
     [self.listenerArray removeAllObjects];
         if(_flexScrollerCSSNode){
-            delete _flexScrollerCSSNode;
-            
-            //WeexCore::WXCoreLayoutNode::freeNodeTree(_flexScrollerCSSNode);
+            [WXComponent recycleNodeOnComponentThread:_flexScrollerCSSNode gabRef:self.ref];
             
             _flexScrollerCSSNode=nullptr;
         }

--- a/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.h
+++ b/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.h
@@ -59,4 +59,7 @@ extern "C" {
 - (void)_insertChildCssNode:(WXComponent*)subcomponent atIndex:(NSInteger)index;
 - (void)_rmChildCssNode:(WXComponent*)subcomponent;
 - (NSInteger) getActualNodeIndex:(WXComponent*)subcomponent atIndex:(NSInteger) index;
+#ifdef __cplusplus
++ (void) recycleNodeOnComponentThread:(WeexCore::WXCoreLayoutNode * ) garbageNode gabRef:(NSString *)ref;
+#endif
 @end

--- a/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.mm
+++ b/ios/sdk/WeexSDK/Sources/Layout/WXComponent+Layout.mm
@@ -637,5 +637,22 @@ static WeexCore::WXCoreSize flexCssNodeMeasure(WeexCore::WXCoreLayoutNode *node,
 }
 
 
++ (void) recycleNodeOnComponentThread:(WeexCore::WXCoreLayoutNode * ) garbageNode gabRef:(NSString *)ref {
+    if (nullptr == garbageNode) {
+#ifdef DEBUG
+        WXLogDebug(@"flexlayout->recycle garbageNode ref:%@ is null ",ref);
+#endif
+        return;
+    }
+    WXPerformBlockOnComponentThread(^{
+#ifdef DEBUG
+        WXLogDebug(@"flexlayout->recycle  ref:%@ ,node:%p",ref,garbageNode );
+#endif
+        if(nullptr != garbageNode){
+            delete garbageNode;
+        }
+    });
+    //domthread
+}
 
 @end

--- a/ios/sdk/WeexSDK/Sources/Layout/WXCoreLayout.h
+++ b/ios/sdk/WeexSDK/Sources/Layout/WXCoreLayout.h
@@ -157,7 +157,16 @@ namespace WeexCore {
         mHasNewLayout = true;
         dirty = true;
         measureFunc = nullptr;
+        if(nullptr != mParent){
+            mParent->removeChild(this);
+        }
         mParent = nullptr;
+        for(WXCoreLayoutNode* childNode : mChildList){
+            if(nullptr != childNode){
+                childNode->mParent = nullptr;
+            }
+        }
+        
         mChildList.clear();
         BFCs.clear();
         NonBFCs.clear();

--- a/ios/sdk/WeexSDK/Sources/Model/WXComponent.mm
+++ b/ios/sdk/WeexSDK/Sources/Model/WXComponent.mm
@@ -222,11 +222,12 @@ static BOOL bNeedRemoveEvents = YES;
 
 - (void)dealloc
 {
-    if(self.flexCssNode){
+    if(_flexCssNode){
 #ifdef DEBUG
         WXLogDebug(@"flexLayout -> dealloc %@",self.ref);
 #endif
-        delete self.flexCssNode;
+        [WXComponent recycleNodeOnComponentThread:_flexCssNode gabRef:_ref];
+        _flexCssNode=nullptr;
     }
     
     // remove all gesture and all


### PR DESCRIPTION
-  history issue 
    - delete node should be in domthread ,now ui thread (due to the ARC)
- rm ref childRef & parent ref when delete node (cause node point EXC-BAD-ACCESS)