### PR TITLE
[WEEX-433] [core] rm jni code from weexcore

### DIFF
--- a/weex_core/Source/CMakeLists.txt
+++ b/weex_core/Source/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.4.1)
 set(WEEXCORE_LIBRARY_NAME weexcore)
 
-add_compile_options(-std=c++11)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+#add_compile_options(-std=c++11)
 add_compile_options(-fexceptions)
 
 add_definitions(-DGNU_SUPPORT=1)
@@ -42,20 +43,21 @@ set(COMMON_SRCS
   ./core/moniter/render_performance.cpp
   ./core/manager/weex_core_manager.cpp
   ./core/bridge/js_bridge.cpp
+  ./core/parser/dom_wson.cpp
         )
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/wson)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/wson)
 
 SET(FINAL_ADD_LIBRARY
         ${COMMON_SRCS}
 )
-SET(FINAL_TARGET_LINK_LIBRARIES )
+SET(FINAL_TARGET_LINK_LIBRARIES wson)
 
 if (ANDROID)
   ## add_subdirectory for subdirectory has a CMakeLists.txt
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/IPC)
   ## include_directories for include head file
   include_directories(${CMAKE_CURRENT_SOURCE_DIR}/IPC)
-  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/wson)
-  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/wson)
 
   set (ANDROID_SRCS
     ./android/jniprebuild/jni_load.cc
@@ -79,7 +81,6 @@ if (ANDROID)
     ./android/jsengine/multiprocess/ExtendJSApi.cpp
 
 
-    ./core/parser/dom_wson.cpp
     ./android/jsengine/api/WeexJSCoreApi.cpp
      
 
@@ -100,9 +101,6 @@ if (ANDROID)
 
 endif (ANDROID)
 
-add_library(${WEEXCORE_LIBRARY_NAME} SHARED
-        ${FINAL_ADD_LIBRARY}
-        )
-
+add_library(${WEEXCORE_LIBRARY_NAME} SHARED ${FINAL_ADD_LIBRARY})
 target_include_directories(${WEEXCORE_LIBRARY_NAME} PUBLIC .)
 target_link_libraries(${WEEXCORE_LIBRARY_NAME} ${FINAL_TARGET_LINK_LIBRARIES})

--- a/weex_core/Source/android/bridge/impl/native_render_object_utils_impl_android.cpp
+++ b/weex_core/Source/android/bridge/impl/native_render_object_utils_impl_android.cpp
@@ -28,6 +28,7 @@
 #include <core/render/node/factory/render_type.h>
 #include <android/log.h>
 #include <core/render/node/render_list.h>
+#include <android/base/log_utils.h>
 
 
 using namespace WeexCore;

--- a/weex_core/Source/core/parser/dom_wson.cpp
+++ b/weex_core/Source/core/parser/dom_wson.cpp
@@ -20,7 +20,6 @@
 // Created by furture on 2018/5/15.
 //
 
-#include <jni.h>
 #include <core/render/node/render_object.h>
 #include <core/render/page/render_page.h>
 #include <core/render/node/factory/render_creator.h>

--- a/weex_core/Source/core/render/action/render_action_appendtree_createfinish.cpp
+++ b/weex_core/Source/core/render/action/render_action_appendtree_createfinish.cpp
@@ -17,7 +17,7 @@
  * under the License.
  */
 #include "render_action_appendtree_createfinish.h"
-#include "../../../android/bridge/impl/bridge_impl_android.h"
+#include <core/manager/weex_core_manager.h>
 
 namespace WeexCore {
 
@@ -27,6 +27,6 @@ namespace WeexCore {
   }
 
   void RenderActionAppendTreeCreateFinish::ExecuteAction() {
-    Bridge_Impl_Android::getInstance()->callAppendTreeCreateFinish(mPageId.c_str(), mRef.c_str());
+    WeexCoreManager::getInstance()->getPlatformBridge()->callAppendTreeCreateFinish(mPageId.c_str(), mRef.c_str());
   }
 }

--- a/weex_core/Source/core/render/node/render_appbar.h
+++ b/weex_core/Source/core/render/node/render_appbar.h
@@ -21,7 +21,7 @@
 
 #include <core/render/node/render_object.h>
 #include <string>
-#include <android/base/string/string_utils.h>
+//#include <android/base/string/string_utils.h>
 
 namespace WeexCore {
   class RenderAppBar : public RenderObject {

--- a/weex_core/Source/core/render/node/render_list.h
+++ b/weex_core/Source/core/render/node/render_list.h
@@ -22,7 +22,6 @@
 #include <core/css/constants_name.h>
 #include <core/render/node/render_object.h>
 #include <core/css/constants_value.h>
-#include <android/base/log_utils.h>
 #include <cmath>
 #include <base/ViewUtils.h>
 #include <core/render/node/factory/render_type.h>

--- a/weex_core/Source/core/render/node/render_mask.h
+++ b/weex_core/Source/core/render/node/render_mask.h
@@ -21,7 +21,6 @@
 
 #include <core/render/node/render_object.h>
 #include <core/config/core_environment.h>
-#include <android/bridge/impl/bridge_impl_android.h>
 #include <base/ViewUtils.h>
 #include <cstdlib>
 

--- a/weex_core/Source/core/render/node/render_object.h
+++ b/weex_core/Source/core/render/node/render_object.h
@@ -22,7 +22,6 @@
 #include <string>
 #include <map>
 #include <set>
-#include <jni.h>
 #include <core/css/constants_name.h>
 #include <core/css/css_value_getter.h>
 #include <core/layout/layout.h>
@@ -31,7 +30,6 @@
 #include <base/ViewUtils.h>
 #include <core/render/page/render_page.h>
 #include <core/css/constants_value.h>
-#include <android/base/log_utils.h>
 #include <functional>
 
 

--- a/weex_core/Source/core/render/node/render_scroller.h
+++ b/weex_core/Source/core/render/node/render_scroller.h
@@ -19,7 +19,6 @@
 #ifndef WEEX_PROJECT_RENDERSCROLLER_H
 #define WEEX_PROJECT_RENDERSCROLLER_H
 
-#include <android/bridge/impl/bridge_impl_android.h>
 #include <core/render/node/render_object.h>
 
 namespace WeexCore {

--- a/weex_core/Source/core/render/page/render_page.cpp
+++ b/weex_core/Source/core/render/page/render_page.cpp
@@ -26,7 +26,6 @@
 #include <core/render/action/render_action_createfinish.h>
 #include <core/render/action/render_action_appendtree_createfinish.h>
 #include <core/layout/layout.h>
-#include <android/base/string/string_utils.h>
 #include <core/moniter/render_performance.h>
 #include <core/config/core_environment.h>
 #include <base/ViewUtils.h>

--- a/weex_core/Source/core/render/page/render_page.h
+++ b/weex_core/Source/core/render/page/render_page.h
@@ -22,7 +22,6 @@
 #include <vector>
 #include <string>
 #include <map>
-#include <jni.h>
 #include <cmath>
 #include <atomic>
 


### PR DESCRIPTION
- rm jni code from weexcore
  - jni.h
  - bridge_impl_android.h
  - android/base/string/string_utils.h
  - android/base/log_utils.h
- edit cmake compile option 
  - use `set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")` to replace `add_compile_options(-std=c++11)`  (see: https://blog.csdn.net/10km/article/details/51731959)
  - for wson error: invalid arguments "-std=c++11" not allowed with 'C 

