### PR TITLE
[WEEX-436] [iOS] fix history issue : delete rootNode in mainThread

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.mm
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.mm
@@ -94,9 +94,11 @@ static NSThread *WXComponentThread;
 - (void)dealloc
 {
     if(_rootFlexCSSNode){
-        delete _rootFlexCSSNode;
-        
-       // WeexCore::WXCoreLayoutNode::freeNodeTree(_rootFlexCSSNode);
+        if ([[NSThread currentThread].name isEqualToString:WX_COMPONENT_THREAD_NAME]) {
+            delete _rootFlexCSSNode;
+        }else{
+            [WXComponent recycleNodeOnComponentThread:_rootFlexCSSNode gabRef:@"_root_p"];
+        }
         _rootFlexCSSNode=nullptr;
     }
     [NSMutableArray wx_releaseArray:_fixedComponents];


### PR DESCRIPTION
fix history issue : delete rootNode in mainThread

in some case ,`WXComponentManager dealloc` execute in mainThread 
but all node operation(new / add / delete/other) should be in ComponentThread
