### PR TITLE
[WEEX-342][android] ava.util.ConcurrentModificationException WXComponent.applyEvents

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/WXEnvironment.java
+++ b/android/sdk/src/main/java/com/taobao/weex/WXEnvironment.java
@@ -43,7 +43,12 @@ import java.util.Map;
 public class WXEnvironment {
 
   public static final String OS = "android";
-  public static final String SYS_VERSION = android.os.Build.VERSION.RELEASE;
+  public static String SYS_VERSION = android.os.Build.VERSION.RELEASE;
+  static{
+    if(SYS_VERSION != null && SYS_VERSION.toUpperCase().equals("P")){
+        SYS_VERSION = "9.0.0";
+    }
+  }
   public static final String SYS_MODEL = android.os.Build.MODEL;
   public static final String ENVIRONMENT = "environment";
   public static final String WEEX_CURRENT_KEY = "wx_current_url";

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
@@ -69,6 +69,7 @@ import com.taobao.weex.common.WXPerformance;
 import com.taobao.weex.common.WXRuntimeException;
 import com.taobao.weex.dom.CSSShorthand;
 import com.taobao.weex.dom.CSSShorthand.CORNER;
+import com.taobao.weex.dom.WXEvent;
 import com.taobao.weex.dom.WXStyle;
 import com.taobao.weex.dom.transition.WXTransition;
 import com.taobao.weex.layout.ContentBoxMeasurement;
@@ -287,7 +288,13 @@ public abstract class WXComponent<T extends View> extends WXBasicComponent imple
   private void applyEvents() {
     if (getEvents() == null || getEvents().isEmpty())
       return;
-    for (String type : getEvents()) {
+    WXEvent event = getEvents();
+    int size = event.size();
+    for(int i=0; i<size; i++){
+      if(i >= event.size()){
+        break;
+      }
+      String type = event.get(i);
       addEvent(type);
     }
     setActiveTouchListener();


### PR DESCRIPTION
1、java.util.ConcurrentModificationException
at java.util.ArrayList$ArrayListIterator.next(ArrayList.java:573)
at com.taobao.weex.ui.component.WXComponent.applyEvents(WXComponent.java:290)
at com.taobao.weex.ui.component.WXComponent.applyLayoutAndEvent(WXComponent.java:635)
at com.taobao.weex.ui.component.WXVContainer.applyLayoutAndEvent(WXVContainer.java:114)
at com.taobao.weex.ui.component.WXVContainer.applyLayoutAndEvent(WXVContainer.java:118)
at com.taobao.weex.ui.component.WXVContainer.applyLayoutAndEvent(WXVContainer.java:118)
at com.taobao.weex.ui.component.list.BasicListComponent.onCreateViewHolder(BasicListComponent.java:968)
at com.taobao.weex.ui.component.list.BasicListComponent.onCreateViewHolder(BasicListComponent.java:89)
at com.taobao.weex.ui.view.listview.adapter.RecyclerViewBaseAdapter.onCreateViewHolder(RecyclerViewBaseAdapter.java:40)
at 

2、Android P return version adapter
[WEEX-342][android] AndroidP only return P without version. return right version