### PR TITLE
[WEEX-443][iOS]Fix picker module callback not called on iOS 11.0.x

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Manager/WXDatePickerManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXDatePickerManager.m
@@ -25,7 +25,7 @@
 
 #define WXPickerHeight 266
 
-@interface WXDatePickerManager()
+@interface WXDatePickerManager() <UIGestureRecognizerDelegate>
 
 @property(nonatomic,strong)UIDatePicker *datePicker;
 @property(nonatomic,strong)UIView *backgroudView;
@@ -46,6 +46,9 @@
         {
             self.backgroudView = [self createBackgroundView];
             UITapGestureRecognizer *tapGesture=[[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(hide)];
+            if (WX_SYS_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+                tapGesture.delegate = self;
+            }
             [self.backgroudView addGestureRecognizer:tapGesture];
         }
         
@@ -209,6 +212,14 @@
         [self.delegate fetchDatePickerValue:value];
     }
     
+}
+
+#pragma mark - UIGestureRecognizerDelegate
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
+    if (self.datePickerView && [touch.view isDescendantOfView:self.datePickerView]) {
+        return NO;
+    }
+    return YES;
 }
 
 @end

--- a/ios/sdk/WeexSDK/Sources/Manager/WXDatePickerManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXDatePickerManager.m
@@ -46,7 +46,7 @@
         {
             self.backgroudView = [self createBackgroundView];
             UITapGestureRecognizer *tapGesture=[[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(hide)];
-            if (WX_SYS_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+            if (WX_SYS_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0") && WX_SYS_VERSION_LESS_THAN(@"11.1")) {
                 tapGesture.delegate = self;
             }
             [self.backgroudView addGestureRecognizer:tapGesture];

--- a/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
@@ -269,7 +269,7 @@ WX_EXPORT_METHOD(@selector(pickTime:callback:))
 {
     self.backgroundView = [self createbackgroundView];
     UITapGestureRecognizer *tapGesture=[[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(hide)];
-    if (WX_SYS_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    if (WX_SYS_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0") && WX_SYS_VERSION_LESS_THAN(@"11.1")) {
         tapGesture.delegate = self;
     }
     [self.backgroundView addGestureRecognizer:tapGesture];
@@ -471,7 +471,7 @@ WX_EXPORT_METHOD(@selector(pickTime:callback:))
 {
     self.backgroundView = [self createbackgroundView];
     UITapGestureRecognizer *tapGesture=[[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(hide)];
-    if (WX_SYS_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    if (WX_SYS_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0") && WX_SYS_VERSION_LESS_THAN(@"11.1")) {
         tapGesture.delegate = self;
     }
     [self.backgroundView addGestureRecognizer:tapGesture];

--- a/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXPickerModule.m
@@ -28,7 +28,7 @@
 #define WXPickerHeight 266
 #define WXPickerToolBarHeight 44
 
-@interface WXPickerModule()
+@interface WXPickerModule() <UIGestureRecognizerDelegate>
 
 @property (nonatomic, strong)NSString * pickerType;
 // when resign the picker ,then the focus will be.
@@ -269,6 +269,9 @@ WX_EXPORT_METHOD(@selector(pickTime:callback:))
 {
     self.backgroundView = [self createbackgroundView];
     UITapGestureRecognizer *tapGesture=[[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(hide)];
+    if (WX_SYS_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+        tapGesture.delegate = self;
+    }
     [self.backgroundView addGestureRecognizer:tapGesture];
     self.pickerView = [self createPickerView];
     UIToolbar *toolBar=[[UIToolbar alloc]initWithFrame:CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, WXPickerToolBarHeight)];
@@ -468,6 +471,9 @@ WX_EXPORT_METHOD(@selector(pickTime:callback:))
 {
     self.backgroundView = [self createbackgroundView];
     UITapGestureRecognizer *tapGesture=[[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(hide)];
+    if (WX_SYS_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+        tapGesture.delegate = self;
+    }
     [self.backgroundView addGestureRecognizer:tapGesture];
     self.pickerView = [self createPickerView];
     UIToolbar *toolBar=[[UIToolbar alloc]initWithFrame:CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, WXPickerToolBarHeight)];
@@ -509,6 +515,14 @@ WX_EXPORT_METHOD(@selector(pickTime:callback:))
         self.callback(@{ @"result": @"success",@"data":value},NO);
         self.callback=nil;
     }
+}
+
+#pragma mark - UIGestureRecognizerDelegate
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
+    if (self.pickerView && [touch.view isDescendantOfView:self.pickerView]) {
+        return NO;
+    }
+    return YES;
 }
 
 @end


### PR DESCRIPTION
On iOS 11.0.x device, the tap gesture hijacked "done" and "cancel" button event.