### PR TITLE
[WEEX-453][iOS] transform/transformOrigin conflict when updateStyles

### DIFF
--- a/ios/sdk/WeexSDK/Sources/View/WXComponent+ViewManagement.mm
+++ b/ios/sdk/WeexSDK/Sources/View/WXComponent+ViewManagement.mm
@@ -251,14 +251,13 @@ do {\
         }
     }
     if (styles[@"transform"]) {
-        _transform = [[WXTransform alloc] initWithCSSValue:[WXConvert NSString:styles[@"transform"]] origin:[WXConvert NSString:self.styles[@"transformOrigin"]] instance:self.weexInstance];
+        id transformOrigin = styles[@"transformOrigin"] ?: self.styles[@"transformOrigin"];
+        _transform = [[WXTransform alloc] initWithCSSValue:[WXConvert NSString:styles[@"transform"]] origin:[WXConvert NSString:transformOrigin] instance:self.weexInstance];
         if (!CGRectEqualToRect(self.calculatedFrame, CGRectZero)) {
             [_transform applyTransformForView:_view];
             [_layer setNeedsDisplay];
         }
-    }
-    
-    if (styles[@"transformOrigin"]) {
+    }else if (styles[@"transformOrigin"]) {
         [_transform setTransformOrigin:[WXConvert NSString:styles[@"transformOrigin"]]];
         if (!CGRectEqualToRect(self.calculatedFrame, CGRectZero)) {
             [_transform applyTransformForView:_view];


### PR DESCRIPTION
only transform ONCE when incoming styles has both `transform` and `transformOrigin`, and use input `transformOrigin` replace `self.styles[@"transformOrigin"]`