### PR TITLE
[WEEX-456][iOS]try to fix bas_access of parentNode

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Layout/WXCoreLayout.h
+++ b/ios/sdk/WeexSDK/Sources/Layout/WXCoreLayout.h
@@ -703,9 +703,10 @@ namespace WeexCore {
       return mChildList.cend();
     }
 
-    inline void removeChild(const WXCoreLayoutNode* const child) {
+    inline void removeChild(WXCoreLayoutNode* const child) {
       for (int index = 0; index < mChildList.size(); index++) {
         if (child == mChildList[index]) {
+          child->mParent = nullptr;
           mChildList.erase(mChildList.begin() + index);
           break;
         }

--- a/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.mm
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.mm
@@ -986,8 +986,25 @@ static NSThread *WXComponentThread;
 - (void)removeFixedComponent:(WXComponent *)fixComponent
 {
     [_fixedComponents removeObject:fixComponent];
-        _rootFlexCSSNode->removeChild(fixComponent->_flexCssNode);
+    [self removeFixFlexNode:fixComponent->_flexCssNode];
 }
+
+- (void)removeFixFlexNode:(WeexCore::WXCoreLayoutNode* )fixNode{
+    if (nullptr == fixNode) {
+        return;
+    }
+    if ([[NSThread currentThread].name isEqualToString:WX_COMPONENT_THREAD_NAME]) {
+        _rootFlexCSSNode->removeChild(fixNode);
+    }else{
+        WXPerformBlockOnComponentThread(^{
+            if (nullptr == fixNode) {
+                return;
+            }
+            _rootFlexCSSNode->removeChild(fixNode);
+        });
+    }
+}
+
 
 @end
 

--- a/ios/sdk/WeexSDK/Sources/Model/WXComponent.mm
+++ b/ios/sdk/WeexSDK/Sources/Model/WXComponent.mm
@@ -222,6 +222,9 @@ static BOOL bNeedRemoveEvents = YES;
 
 - (void)dealloc
 {
+    if (_positionType == WXPositionTypeFixed) {
+        [self.weexInstance.componentManager removeFixedComponent:self];
+    }
     if(_flexCssNode){
 #ifdef DEBUG
         WXLogDebug(@"flexLayout -> dealloc %@",self.ref);
@@ -255,10 +258,6 @@ static BOOL bNeedRemoveEvents = YES;
         if (WX_SYS_VERSION_LESS_THAN(@"9.0")) {
             [self _removeAllEvents];
         }
-    }
-
-    if (_positionType == WXPositionTypeFixed) {
-        [self.weexInstance.componentManager removeFixedComponent:self];
     }
 
     pthread_mutex_destroy(&_propertyMutex);


### PR DESCRIPTION
- set `node->parent=null` when remove node
- `removeFixedComponent` should be called before `delete node`
- `removeNode` should called in componentThread