### PR TITLE
[build] update dependent version of node.js

### DIFF
--- a/HOW-TO-BUILD.md
+++ b/HOW-TO-BUILD.md
@@ -1,5 +1,5 @@
-# Weex Apache Source Release   
-Weex produce SDKs to integrate to iOS/Android/Mobile web applications. This file will cover how to build Weex from source. You can either use the script we provided or manually build from source step by step.   
+# Weex Apache Source Release
+Weex produce SDKs to integrate to iOS/Android/Mobile web applications. This file will cover how to build Weex from source. You can either use the script we provided or manually build from source step by step.
 See `README.md` for further information about Weex Framework.
 
 Weex SDK includes 3 different SDKs to use in corresponding system/browser:
@@ -12,22 +12,22 @@ See our [guide in our website](http://weex.apache.org/guide/integrate-to-your-ap
 ## Build Environment
 The environment required to build weex as follow:
 * Android SDK:
-    * NodeJS 4.0+
+    * NodeJS 8.0+
     * JDK 1.6+
     * Android SDK(`$ANDROID_HOME` must be set properly)
     * Android NDK(`$ANDROID_NDK` must be set properly)
     * Gradle 2.0+
 * iOS SDK:
-    * NodeJS 4.0+
+    * NodeJS 8.0+
     * XCode & Command Tools 8.0+
 * Mobile web SDK:
-    * NodeJS 4.0+
+    * NodeJS 8.0+
 
 This article was tested in MacOSX system.
 
 # Build All by Script
 
-This script will build Android and iOS SDKs:   
+This script will build Android and iOS SDKs:
 > `$ bash scripts/build_from_source.sh`
 
 This's may take a while. After that, you can look into `dist/`, `android/sdk/build/output/` and `ios/sdk/Products` for Web/Android/iOS SDK artifacts.
@@ -48,14 +48,14 @@ Build the javascript libraries:
 > `$ npm run build:source`
 
 ### Before build Native SDK
-Move `min` version to Native SDK folder, which will be used by native SDK build.   
-> `cp packages/weex-js-framework/index.min.js ios_sdk/WeexSDK/Resources/main.js`   
+Move `min` version to Native SDK folder, which will be used by native SDK build.
+> `cp packages/weex-js-framework/index.min.js ios_sdk/WeexSDK/Resources/main.js`
 > `cp packages/weex-js-framework/index.min.js android_sdk/assets/main.js`
 
-## Build Android SDK    
-Make sure you have install gradle, see more details about 'how to install gradle' in [gradle website](https://gradle.org/install).   
-execute root folder of project   
-> `$ gradle wrapper --gradle-version 2.14.1`   
+## Build Android SDK
+Make sure you have install gradle, see more details about 'how to install gradle' in [gradle website](https://gradle.org/install).
+execute root folder of project
+> `$ gradle wrapper --gradle-version 2.14.1`
 
 Create a Gradle setting file
 > `$ echo 'include ":android_sdk"'>settings.gradle`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please ***INSTALL [Git for Windows](https://git-scm.com/download/win)*** and run
 ## Meet Weex
 
 * Install [Weex Playground App](https://weex.apache.org/tools/playground.html) to see examples we already written.
-* If you want to write a demo, install [weex-toolkit](https://www.npmjs.com/package/weex-toolkit) in [Node.js](http://nodejs.org/) 4.0+ and
+* If you want to write a demo, install [weex-toolkit](https://www.npmjs.com/package/weex-toolkit) in [Node.js](http://nodejs.org/) 8.0+ and
 * Run `weex init` to generate & start a simple project in an empty folder.
 * Follow the instructions in the project README.
 * Enjoy it.
@@ -32,7 +32,7 @@ Please ***INSTALL [Git for Windows](https://git-scm.com/download/win)*** and run
 ### Android
 
 * Prerequisites
-  * Install [Node.js](http://nodejs.org/) 4.0+
+  * Install [Node.js](http://nodejs.org/) 8.0+
   * Under project root
     * `npm install`, install project
     * `./start`
@@ -50,7 +50,7 @@ On Android Platform , Weex code is executed in [weex_v8core](https://github.com/
 ### iOS
 * run playground
   * Prerequisites
-    * Install [Node.js](http://nodejs.org/) 4.0+
+    * Install [Node.js](http://nodejs.org/) 8.0+
       * Under project root
           * `npm install`, install project
           * `./start`
@@ -66,15 +66,15 @@ On Android Platform , Weex code is executed in [weex_v8core](https://github.com/
 * integrate to your application
 
   - **[CocoaPods](https://cocoapods.org)**
-  
+
      Add the following line to your Podfile:
    ```
      pod 'WeexSDK'
    ```
     run `pod install`
-    
+
   - **[Carthage](https://github.com/carthage/carthage)**
-  
+
     Add the following line to your Cartfile:
    ```
      github "apache/incubator-weex"


### PR DESCRIPTION
Update the dependent version of Node.js to keep consistent with [package.json](https://github.com/apache/incubator-weex/blob/939be31e6f37340f81fa396df7bbec27e50c7c15/package.json#L34-L36). (To build js framework correctly, the version of Node.js should be higher than `v7.6.0`.)