### PR TITLE
[Relese] Fixed the sed issue

### DIFF
--- a/scripts/generate_apache_release.sh
+++ b/scripts/generate_apache_release.sh
@@ -11,9 +11,14 @@ rm -rf $dest
 mkdir $dest
 rsync -r --include-from=scripts/release_files.rules ./ $dest
 
+SED_CMD=sed
+if [ $(uname) == 'Darwin' ]; then
+  SED_CMD=/usr/bin/sed
+fi
+
 #repackage
-find $dest/android/sdk -type f \( -name '*.java' -o -name 'AndroidManifest.xml' -o -name 'proguard-rules.pro' \) -exec sed -i 's/com\.taobao\.weex/org\.apache\.weex/g' {} \;
-find $dest/ios/sdk -type f \( -name 'project.pbxproj' -o -name '*.h' -o -name '*.m' -o -name '*.mm' \) -exec sed -i 's/com\.taobao\.weex/org\.apache\.weex/g' {} \;
+find $dest/android/sdk -type f \( -name '*.java' -o -name 'AndroidManifest.xml' -o -name 'proguard-rules.pro' \) -exec $SED_CMD -i '' 's/com\.taobao\.weex/org\.apache\.weex/g' {} \;
+find $dest/ios/sdk -type f \( -name 'project.pbxproj' -o -name '*.h' -o -name '*.m' -o -name '*.mm' \) -exec $SED_CMD -i '' 's/com\.taobao\.weex/org\.apache\.weex/g' {} \;
 
 mkdir -p $dest/android/sdk/src/main/java/org
 mkdir -p $dest/android/sdk/src/main/java/org/apache
@@ -27,8 +32,8 @@ rm -rf $dest/android/sdk/src/test/java/com
 
 mv $dest/ios/sdk $dest/ios_sdk
 mv $dest/android/sdk $dest/android_sdk
-sed -i 's/\.\.\/\.\.\/weex_core/\.\.\/weex_core/g' $dest/android_sdk/build.gradle
-sed -i 's/\.\.\/\.\.\/pre-build/\.\.\/pre-build/g' $dest/android_sdk/build.gradle $dest/ios_sdk/WeexSDK.xcodeproj/project.pbxproj
+$SED_CMD -i '' 's/\.\.\/\.\.\/weex_core/\.\.\/weex_core/g' $dest/android_sdk/build.gradle
+$SED_CMD -i '' 's/\.\.\/\.\.\/pre-build/\.\.\/pre-build/g' $dest/android_sdk/build.gradle $dest/ios_sdk/WeexSDK.xcodeproj/project.pbxproj
 mv $dest/android/build.gradle $dest/build.gradle
 rm -rf $dest/android $dest/ios
 


### PR DESCRIPTION
Use Mac sed to generate release source packages instead of using
gnu-sed, if you installed gnu-sed on your Mac.