### PR TITLE
[WEEX-487][Android] bug fix: scrollable="false" not work on android

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSlider.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSlider.java
@@ -400,9 +400,7 @@ public class WXSlider extends WXVContainer<FrameLayout> {
   @WXComponentProp(name = Constants.Name.SCROLLABLE)
   public void setScrollable(boolean scrollable) {
     if (mViewPager != null && mAdapter != null) {
-      if(mAdapter.getRealCount() > 0){
-        mViewPager.setScrollable(scrollable);
-      }
+      mViewPager.setScrollable(scrollable);
     }
   }
 


### PR DESCRIPTION
[WEEX-487][Android] bug fix: scrollable="false" not work on android

issue: [[WEEX-487]](https://issues.apache.org/jira/browse/WEEX-487)

remove `mAdapter.getRealCount() > 0` from [WXSlider.setScrollable(boolean scrollable)](https://github.com/apache/incubator-weex/blob/master/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSlider.java#L403:10)
```java
  @WXComponentProp(name = Constants.Name.SCROLLABLE)
  public void setScrollable(boolean scrollable) {
    if (mViewPager != null && mAdapter != null) {
      if(mAdapter.getRealCount() > 0){ //remove this line, because there is no data when init slider
        mViewPager.setScrollable(scrollable);
      }
    }
  }
```
