### PR TITLE
* [jsfm] using rollup.watch to fix dev build

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -20,7 +20,6 @@
 const fs = require('fs')
 const path = require('path')
 const rollup = require('rollup')
-const watch = require('rollup-watch')
 const getConfig = require('./config')
 
 let isWatch = false
@@ -37,17 +36,19 @@ else {
 }
 
 function runRollupOnWatch (config) {
-  const watcher = watch(rollup, config)
+  const watcher = rollup.watch(config)
   watcher.on('event', event => {
     switch (event.code) {
-      case 'STARTING': console.log('checking rollup-watch version...'); break
-      case 'BUILD_START': console.log('bundling...'); break
-      case 'BUILD_END': {
-        console.log('bundled in ' + path.relative(process.cwd(), config.dest)
+      case 'START': break
+      case 'BUNDLE_START': console.log('bundling...'); break
+      case 'BUNDLE_END': {
+        console.log('bundled in ' + config.output.file
           + ' (' + event.duration + 'ms)')
         console.log('Watching for changes...')
       } break
+      case 'END': break
       case 'ERROR': console.error('ERROR: ', event.error); break
+      case 'FATAL': console.error('FATAL: ', event.error); break
       default: console.error('unknown event', event)
     }
   })

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-uglify": "^2.0.1",
-    "rollup-watch": "^4.3.1",
     "selenium-server": "2.53.1",
     "serve": "^1.4.0",
     "shelljs": "^0.7.8",


### PR DESCRIPTION
The `rollup-watch` package is deprecated and it will cause error:
```
$ npm run dev:jsfm
(node:40511) UnhandledPromiseRejectionWarning: TypeError: Cannotread property 'map' of undefined
```
![image](https://user-images.githubusercontent.com/8298849/42163619-e33a3cbc-7e35-11e8-8042-39a9c4079126.png)

Using `rollup.watch` to fix this issue.
