### PR TITLE
Change linked c++ library from libstdc++ to libc++

### DIFF
--- a/WeexSDK.podspec
+++ b/WeexSDK.podspec
@@ -42,6 +42,6 @@ Pod::Spec.new do |s|
   s.xcconfig = { "OTHER_LINK_FLAG" => '$(inherited) -ObjC'}
 
   s.frameworks = 'CoreMedia','MediaPlayer','AVFoundation','AVKit','JavaScriptCore', 'GLKit', 'OpenGLES', 'CoreText', 'QuartzCore', 'CoreGraphics'
-  s.libraries = "stdc++"
+  s.libraries = "c++"
 
 end


### PR DESCRIPTION
Apple announced deprecation of libstdc++ about 5 years ago.

Support for it was removed from the iOS 12.0 Simulator runtime, but it remains in the iOS 12.0 (device) runtime for binary compatibility with shipping apps.

see: https://twitter.com/jeremyhu/status/1003882060556062720