### PR TITLE
[WEEX-525] Created the automate beta branch-off scripts.

### DIFF
--- a/scripts/beta-branchoff.sh
+++ b/scripts/beta-branchoff.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+dir_name=$(dirname $0)
+source ${dir_name}/common.sh
+
+function isValidVersion () {
+  echo "$1" | awk '/^[0-9]+\.[0-9]+(\.[0-9]+){0,2}(-rc[0-9]+|-beta[0-9]+)?$/ {print $0}'
+}
+
+function isBetaVersion () {
+  echo "$1" | awk '/^[0-9]+\.[0-9]+(\.[0-9]+){0,2}-beta[0-9]+$/ {print $0}'
+}
+
+function isRCVersion () {
+  echo "$1" | awk '/^[0-9]+\.[0-9]+(\.[0-9]+){0,2}-rc[0-9]+$/ {print $0}'
+}
+
+function latestVersion () {
+  git tag -l | awk '/^0\.[0-9]+(\.[0-9]+){0,2}(-rc[0-9]+|-beta[0-9]+)?$/ { print $0 }' | sort -rV | head -n 1
+}
+
+function latestNotRCVersion () {
+  git tag -l | awk '/^0\.[0-9]+(\.[0-9]+){0,2}(-beta[0-9]+)?$/ { print $0 }' | sort -rV | head -n 1
+}
+
+function betaNumber () {
+  echo "$1" | awk -F 'beta' '{print $2}'
+}
+
+function rcNumber () {
+  echo "$1" | awk -F 'rc' '{print $2}'
+}
+
+function gitRepoModified () {
+  git status --short | awk '/^[ M][ M] / { print $0 }'
+}
+
+function increaseBetaVersion () {
+  if [ $(isRCVersion "$1") ]; then
+    # Unable to increase beta version number on a RC version, exit.
+    return 1
+  fi
+  if [ $(isBetaVersion "$1") ]; then
+    echo "$1" | awk -F 'beta' '{printf("%sbeta%d\n", $1, $2+1)}'
+  else
+    echo "$1" | awk -F '.' '/^([0-9]+\.){1,3}([0-9]+)$/ {
+      for(i=1;i<=NF;i++) {
+        if (i==NF) {
+          printf("%d-beta1\n", $i+1)
+        } else {
+          printf("%d.", $i)
+        }
+      }
+    }'
+  fi
+}
+
+function increaseRCVersion () {
+  if [ $(isBetaVersion "$1") ]; then
+    # Unable to increase rc version number on a beta version, exit.
+    return 1
+  fi
+  if [ $(isRCVersion "$1") ]; then
+    echo "$1" | awk -F 'rc' '{printf("%src%d\n", $1, $2+1)}'
+  else
+    echo "$1" | awk -F '.' '/^([0-9]+\.){1,3}([0-9]+)$/ {
+      for(i=1;i<=NF;i++) {
+        if (i==NF) {
+          printf("%d-rc1\n", $i+1)
+        } else {
+          printf("%d.", $i)
+        }
+      }
+    }'
+  fi
+}
+
+read -e -p "Your upstream git remote is? [origin]"
+remote=${REPLY:="origin"}
+
+info "Fetching latest changes and prune ${LGREEN}$remote${RESTORE}..."
+git fetch -p -t "$remote"
+if [ $? ]; then
+  error "It is not able to fetch codes from your $remote, check if there is any issue."
+  exit 1
+fi
+git remote prune "$remote"
+info "${GREEN}Done.${RESTORE}"
+
+latest_ver=$(latestNotRCVersion)
+beta_ver="0.0.1-beta1"
+if [ -z "$latest_ver" ]; then
+  echo "Use ${YELLOW}$beta_ver${RESTORE} as the version number."
+else
+  beta_ver=$(increaseBetaVersion "$latest_ver")
+fi
+
+beta_branch="$beta_ver-$(date "+%y%m%d")"
+
+info "\nThe latest non-RC version is: ${CYAN}'$latest_ver'${RESTORE}"
+info "This beta version number should be: ${CYAN}'$beta_ver'${RESTORE}"
+info "The beta release branch name should be: ${CYAN}'$beta_branch'${RESTORE}."
+
+is_remote_branch_exist=$(git branch -r | awk '/'"$beta_ver"'/ {print $0}')
+if [ "$is_remote_branch_exist" ]; then
+  warning "Remote branch with beta version $beta_ver already exists, will quit."
+  exit 1
+fi
+
+latest_sha=$(git show --format=%h -s)
+notice "\nMake sure the latest commit SHA on master is:"
+notice "${GREEN}$latest_sha${RESTORE}"
+notice "If it is not the branch-off point you want, update the $remote/master first."
+notice "Also make sure you have the permisison to push branch onto your $remote."
+
+read -e -p "Continue? [Y/n] " -n 1
+shouldContinue=${REPLY:=y}
+if [ ${shouldContinue,,} = n ]; then
+  info "Sure, bye."
+  exit 0
+fi
+
+if [ "$(gitRepoModified)" ]; then
+  read -e -p "Your working directory is modified, stash it? [Y/n]" -n 1
+  shouldStash=${REPLY:=y}
+  if [ ${shouldStash,,} = y ]; then
+    git stash
+  else
+    info "Change ignored."
+  fi
+fi
+
+echo -e "\nCreating local branch: ${YELLOW}$beta_branch${RESTORE}..."
+git checkout -B "$beta_branch" "$latest_sha"
+
+echo -e "\nPushing ${YELLOW}$beta_branch${RESTORE} onto $remote..."
+git push "$remote" "$beta_branch":"$beta_branch"
+git branch --set-upstream-to="$remote/$beta_branch"
+echo "${GREEN}Done.${RESTORE}"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+RESTORE=$(echo -en '\033[0m')
+RED=$(echo -en '\033[00;31m')
+GREEN=$(echo -en '\033[00;32m')
+YELLOW=$(echo -en '\033[00;33m')
+BLUE=$(echo -en '\033[00;34m')
+MAGENTA=$(echo -en '\033[00;35m')
+PURPLE=$(echo -en '\033[00;35m')
+CYAN=$(echo -en '\033[00;36m')
+LIGHTGRAY=$(echo -en '\033[00;37m')
+LRED=$(echo -en '\033[01;31m')
+LGREEN=$(echo -en '\033[01;32m')
+LYELLOW=$(echo -en '\033[01;33m')
+LBLUE=$(echo -en '\033[01;34m')
+LMAGENTA=$(echo -en '\033[01;35m')
+LPURPLE=$(echo -en '\033[01;35m')
+LCYAN=$(echo -en '\033[01;36m')
+WHITE=$(echo -en '\033[01;37m')
+
+function info () {
+  echo -e $*
+}
+
+function notice () {
+  echo -e "${CYAN}$*${RESTORE}"
+}
+
+function warning () {
+  echo -e "${YELLOW}$*${RESTORE}"
+}
+
+function error () {
+  echo -e "${RED}$*${RESTORE}"
+}


### PR DESCRIPTION
The script beta-branchoff.sh is to automate the weekly beta release
branch-off procedure. It helps to identify which is the latest
non-RC version number and release a new beta branch with the number.
The branch will be branched-off from origin/master and will be pushed
onto apache after its creation.

A valid beta version number looks like: 0.18.0-beta1
A Valid beta branch name looks like: 0.18.0-beta1-180720

common.sh provides some useful gadgets for the scripts and can be
shared across scripts.
