### PR TITLE
[WEEX-524][iOS] Try to fix a crash operating mutable array in multi-thread

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Bridge/WXBridgeContext.m
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXBridgeContext.m
@@ -65,7 +65,7 @@ _Pragma("clang diagnostic pop") \
 //store the methods which will be executed from native to js
 @property (nonatomic, strong) NSMutableDictionary   *sendQueue;
 //the instance stack
-@property (nonatomic, strong) WXThreadSafeMutableArray    *insStack;
+@property (nonatomic, strong) NSMutableArray    *insStack;
 //identify if the JSFramework has been loaded
 @property (nonatomic) BOOL frameworkLoadFinished;
 //store some methods temporarily before JSFramework is loaded
@@ -415,7 +415,7 @@ _Pragma("clang diagnostic pop") \
 {
     if (_insStack) return _insStack;
 
-    _insStack = [WXThreadSafeMutableArray array];
+    _insStack = [NSMutableArray array];
     
     return _insStack;
 }
@@ -662,9 +662,7 @@ _Pragma("clang diagnostic pop") \
     
     //remove instance from stack
 	@synchronized(self) {
-		if([self.insStack containsObject:instance]){
-			[self.insStack removeObject:instance];
-		}
+		[self.insStack removeObject:instance];
 	}
     
     if(_jsBridge && [_jsBridge respondsToSelector:@selector(removeTimers:)]){

--- a/ios/sdk/WeexSDK/Sources/Bridge/WXBridgeContext.m
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXBridgeContext.m
@@ -422,12 +422,13 @@ _Pragma("clang diagnostic pop") \
 
 - (WXSDKInstance *)topInstance
 {
-    if (self.insStack.count > 0) {
-        WXSDKInstance *topInstance = [WXSDKManager instanceForID:[self.insStack firstObject]];
-        return topInstance;
-    }
-    
-    return nil;
+	WXSDKInstance *topInstance = nil;
+	@synchronized(self) {
+		if (self.insStack.count > 0) {
+			topInstance = [WXSDKManager instanceForID:[self.insStack firstObject]];
+		}
+	}
+    return topInstance;
 }
 
 - (NSMutableDictionary *)sendQueue
@@ -493,14 +494,16 @@ _Pragma("clang diagnostic pop") \
 {
     WXAssertBridgeThread();
     WXAssertParam(instanceIdString);
-    
-    if (![self.insStack containsObject:instanceIdString]) {
-        if ([options[@"RENDER_IN_ORDER"] boolValue]) {
-            [self.insStack addObject:instanceIdString];
-        } else {
-            [self.insStack insertObject:instanceIdString atIndex:0];
-        }
-    }
+	
+	@synchronized(self) {
+		if (![self.insStack containsObject:instanceIdString]) {
+			if ([options[@"RENDER_IN_ORDER"] boolValue]) {
+				[self.insStack addObject:instanceIdString];
+			} else {
+				[self.insStack insertObject:instanceIdString atIndex:0];
+			}
+		}
+	}
     
     //create a sendQueue bind to the current instance
     NSMutableArray *sendQueue = [NSMutableArray array];
@@ -658,9 +661,11 @@ _Pragma("clang diagnostic pop") \
     WXAssertParam(instance);
     
     //remove instance from stack
-    if([self.insStack containsObject:instance]){
-        [self.insStack removeObject:instance];
-    }
+	@synchronized(self) {
+		if([self.insStack containsObject:instance]){
+			[self.insStack removeObject:instance];
+		}
+	}
     
     if(_jsBridge && [_jsBridge respondsToSelector:@selector(removeTimers:)]){
         [_jsBridge removeTimers:instance];
@@ -896,19 +901,21 @@ _Pragma("clang diagnostic pop") \
     BOOL hasTask = NO;
     NSMutableArray *tasks = [NSMutableArray array];
     NSString *execIns = nil;
-    
-    for (NSString *instance in self.insStack) {
-        NSMutableArray *sendQueue = self.sendQueue[instance];
-        if(sendQueue.count > 0){
-            hasTask = YES;
-            for(WXCallJSMethod *method in sendQueue){
-                [tasks addObject:[method callJSTask]];
-            }
-            [sendQueue removeAllObjects];
-            execIns = instance;
-            break;
-        }
-    }
+	
+	@synchronized(self) {
+		for (NSString *instance in self.insStack) {
+			NSMutableArray *sendQueue = self.sendQueue[instance];
+			if(sendQueue.count > 0){
+				hasTask = YES;
+				for(WXCallJSMethod *method in sendQueue){
+					[tasks addObject:[method callJSTask]];
+				}
+				[sendQueue removeAllObjects];
+				execIns = instance;
+				break;
+			}
+		}
+	}
     
     if ([tasks count] > 0 && execIns) {
         WXSDKInstance * execInstance = [WXSDKManager instanceForID:execIns];


### PR DESCRIPTION
Try to fix a crash:

Terminating app due to uncaught exception 'NSRangeException', reason: '*** -[__NSArrayM objectAtIndexedSubscript:]: index 0 beyond bounds for empty array'

Last Exception Backtrace:
0 CoreFoundation __exceptionPreprocess :228 (in CoreFoundation)
1 _objc_exception_throw :56
2 CoreFoundation _CFThrowFormattedException :112 (in CoreFoundation)
3 -[__NSArrayM objectAtIndexedSubscript:] :192 (in CoreFoundation)
4 -[WXThreadSafeMutableArray objectAtIndex:] WXThreadSafeMutableArray.m:0
5 -[WXBridgeContext topInstance] WXBridgeContext.m:0
6 +[WXSDKEngine topInstance] WXSDKEngine.m:277