### PR TITLE
[WEEX-535][iOS] add extMsg when reproteror for containerinfo

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.h
+++ b/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.h
@@ -75,6 +75,8 @@ extern NSString *const bundleUrlOptionKey;
  **/
 @property (nonatomic, assign) BOOL needPrerender;
 
+@property (nonatomic , strong) NSDictionary* containerInfo;
+
 /**
  * The state of current instance.
  **/

--- a/ios/sdk/WeexSDK/Sources/Monitor/WXExceptionUtils.m
+++ b/ios/sdk/WeexSDK/Sources/Monitor/WXExceptionUtils.m
@@ -40,6 +40,11 @@
         WXSDKInstance * instance = [WXSDKManager instanceForID:instanceId];
         if(instance){
             bundleUrlCommit = instance.pageName?:([instance.scriptURL absoluteString]?:bundleUrlCommit);
+            if (instance.containerInfo && instance.containerInfo.count >0) {
+                NSMutableDictionary* extInfo = [[NSMutableDictionary alloc] initWithDictionary:extParams];
+                [extInfo addEntriesFromDictionary:instance.containerInfo];
+                extParams = extInfo;
+            }
         }else if([instanceIdCommit hasPrefix:@"WX_KEY_EXCEPTION"]){
             bundleUrlCommit = instanceId;
         }


### PR DESCRIPTION
add extMsg when reproteror for containerinfo

use case :

```
instance.containerInfo = @{
       @"aaa":@(1),
       @"bbb":@"vvvvvvvv"
}
```