### PR TITLE
[jsfm] add try catch for callback function and event handler

### DIFF
--- a/runtime/bridge/CallbackManager.js
+++ b/runtime/bridge/CallbackManager.js
@@ -76,7 +76,11 @@ export default class CallbackManager {
       delete this.callbacks[callbackId]
     }
     if (typeof callback === 'function') {
-      return callback(data)
+      try {
+        return callback.call(null, data)
+      } catch (error) {
+        console.error(`[JS Framework] Failed to execute the callback function:\n + ${error.toString()}`)
+      }
     }
     return new Error(`invalid callback id "${callbackId}"`)
   }

--- a/runtime/vdom/Element.js
+++ b/runtime/vdom/Element.js
@@ -450,11 +450,16 @@ export default class Element extends Node {
       event.stopPropagation = () => {
         isStopPropagation = true
       }
-      if (options && options.params) {
-        result = handler.call(this, ...options.params, event)
-      }
-      else {
-        result = handler.call(this, event)
+      try {
+        if (options && options.params) {
+          result = handler.call(this, ...options.params, event)
+        }
+        else {
+          result = handler.call(this, event)
+        }
+      } catch (error) {
+        console.error(`[JS Framework] Failed to invoke the event handler of "${type}" `
+          + `on ${this.type} (${this.ref}):\n ${error.toString()}`)
       }
     }
 


### PR DESCRIPTION
In practice, most js error happens in the js bundle code, which could be a callback function or event handler of js framework. Add try catch on them could make js framework more stable and reduce js crashes.