### PR TITLE
Revert "* [android] Use rint on getFloatByViewport."

### DIFF
--- a/weex_core/Source/base/ViewUtils.h
+++ b/weex_core/Source/base/ViewUtils.h
@@ -64,7 +64,7 @@ namespace WeexCore {
 
     float realPx = (src * WXCoreEnvironment::getInstance()->DeviceWidth() /
                     viewport);
-    float result = realPx > 0.005 && realPx < 1 ? 1.0f : rint(realPx);
+    float result = realPx > 0.005 && realPx < 1 ? 1.0f : realPx;
     return result;
   }
 


### PR DESCRIPTION
This commit may trigger the mistake of Layout which need a better solution.