### PR TITLE
* [Android] Fix module memroy leak. 

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/WXSDKEngine.java
+++ b/android/sdk/src/main/java/com/taobao/weex/WXSDKEngine.java
@@ -347,18 +347,18 @@ public class WXSDKEngine implements Serializable {
       registerComponent(WXBasicComponentType.LOADING_INDICATOR, WXLoadingIndicator.class);
       registerComponent(WXBasicComponentType.HEADER, WXHeader.class);
 
-      registerModule("modal", WXModalUIModule.class, false);
-      registerModule("instanceWrap", WXInstanceWrap.class, false);
-      registerModule("animation", WXAnimationModule.class, false);
-      registerModule("webview", WXWebViewModule.class, true);
+      registerModule("modal", WXModalUIModule.class);
+      registerModule("instanceWrap", WXInstanceWrap.class);
+      registerModule("animation", WXAnimationModule.class);
+      registerModule("webview", WXWebViewModule.class);
       registerModule("navigator", WXNavigatorModule.class);
       registerModule("stream", WXStreamModule.class);
-      registerModule("timer", WXTimerModule.class, false);
-      registerModule("storage", WXStorageModule.class, true);
-      registerModule("clipboard", WXClipboardModule.class, true);
+      registerModule("timer", WXTimerModule.class);
+      registerModule("storage", WXStorageModule.class);
+      registerModule("clipboard", WXClipboardModule.class);
       registerModule("globalEvent",WXGlobalEventModule.class);
       registerModule("picker", WXPickersModule.class);
-      registerModule("meta", WXMetaModule.class,true);
+      registerModule("meta", WXMetaModule.class);
       registerModule("webSocket", WebSocketModule.class);
       registerModule("locale", WXLocaleModule.class);
     } catch (WXException e) {


### PR DESCRIPTION
Switch all the global modules in weex_sdk to instance modules.

(cherry picked from commit 77fa800)