### PR TITLE
[doc] Update the issue template on GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,41 +1,24 @@
 <!--
-
-Notes: Weex will move into Apache Software Foundation (ASF) on Feb 24 2017.
-
-Our new GitHub repo is https://github.com/apache/incubator-weex
-
-You can continue to discuss with us through ASF Mailing List:
-http://mail-archives.apache.org/mod_mbox/#weex.incubator
-or StackOverflow:
-http://stackoverflow.com/questions/tagged/weex
-
-Thank you for your support.
-
-----
-
-注意：Weex 将于 2017-02-24 迁移至 Apache 基金会
-
-届时我们会使用新的 GitHub 仓库：https://github.com/apache/incubator-weex
-同时欢迎大家在 SegmentFault 的 Weex 版块进行中文讨论 https://segmentfault.com/t/weex
-
-更多详情请关注：https://github.com/weexteam/article/issues/130
-
-感谢理解和支持
-
+Thanks for using Weex. Please follow the [Bug Report Guidelines](http://weex-project.io/bug-report-guidelines.html) to file issues. A good bug report should include the following information:
 -->
 
 <!--
-
-0. It's ***RECOMMENDED*** to [submit PR](https://github.com/alibaba/weex/pulls) for typo, new demo or tiny bugfix.
-0. If this's a ***BUG***, pls provide: course repetition, error/crash log, device model, OS version, App version (playground or other apps).
-0. If this's a ***FEATURE***, pls provide: details, pseudo codes if necessary.
-
-----
-
-（请在***提交***前删除这段描述）
-
-0. 我们***推荐***小问题直接[提 PR](https://github.com/alibaba/weex/pulls)，如错别字、新 demo 或 bugfix。
-0. 如果是 ***Bug***，请提供：复现步骤（推荐有截图）、error/crash log、设备型号、OS 版本、App 版本（playground 版本或自己的 app）。
-0. 如果是***新需求***，请提供：详细描述、应用场景、适当的伪代码（如有）。
-
+感谢使用 Weex。请遵照 [Bug 报告指南](http://weex-project.io/cn/bug-report-guidelines.html) 创建 issue，希望你可以提供如下信息：
 -->
+
+## Description
+
+<!-- The brief description of the potential bug. -->
+
+## Environment
+
+<!-- The environment to reproduce this bug, such as **Weex Version** and **Device Mode**. -->
+<!-- You can get those information throw [this example](http://dotwe.org/vue/1dea64f527db3fd109c0fb682d41c14f). -->
+
+## Broken Example
+
+<!-- Please offer an example on the [online editor of Weex](http://dotwe.org/) to reproduce the bug. -->
+
+## Steps to Reproduce
+
+<!-- Clear and concise steps to reproduce the bug. -->


### PR DESCRIPTION
Since weex opened [the issue panel](https://github.com/apache/incubator-weex/issues) now, the template of it should be updated as well.

It will be shown when developers trying to file an issue of Weex on GitHub.