### PR TITLE
[WEEX-558][Android] Font file url compatible with ' and "

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/utils/FontDO.java
+++ b/android/sdk/src/main/java/com/taobao/weex/utils/FontDO.java
@@ -73,7 +73,7 @@ public class FontDO {
       return;
     }
 
-    if (src.matches("^url\\('.*'\\)$")) {
+    if (src.matches("^url\\((('[^']*')|(\"[^\"]*\"))\\)$")) {
       String url = src.substring(5, src.length() - 2);
       Uri uri = Uri.parse(url);
       if( instance != null){

--- a/android/sdk/src/main/java/com/taobao/weex/utils/FontDO.java
+++ b/android/sdk/src/main/java/com/taobao/weex/utils/FontDO.java
@@ -73,7 +73,7 @@ public class FontDO {
       return;
     }
 
-    if (src.matches("^url\\((('[^']*')|(\"[^\"]*\"))\\)$")) {
+    if (src.matches("^url\\((('.*')|(\".*\"))\\)$")) {
       String url = src.substring(5, src.length() - 2);
       Uri uri = Uri.parse(url);
       if( instance != null){


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/WEEX-558

use costumer fontFace like this:
```
const domModule = weex.requireModule('dom')
domModule.addRule('fontFace', {
  'fontFamily': "iconfont2",
  'src': "url('http://at.alicdn.com/t/font_1469606063_76593.ttf')"
})
```
double quotes is outside for font file url,  it will make an error with lint.

when set as this, the font face does not work with android:
```
  'src': 'url("http://at.alicdn.com/t/font_1469606063_76593.ttf")'
```

it cause by [FontDO](https://github.com/apache/incubator-weex/blob/master/android/sdk/src/main/java/com/taobao/weex/utils/FontDO.java#76)





