### PR TITLE
[devtool] Added beta-signoff.sh to automate the beta release process.

### DIFF
--- a/scripts/beta-signoff.sh
+++ b/scripts/beta-signoff.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# This script publishes the latest beta version of the project, merge beta changes to beta branch, and tags the beta release, then rebase the changes onto master branch, and cleanup temporary release branches as well.
+
+dir_name=$(dirname $0)
+source ${dir_name}/common.sh
+
+command -v hub > /dev/null 2>&1 || { error "The signoff process needs command 'hub', Use 'brew install hub' to install it. exit."; exit 1; }
+
+prepareWorkingDir
+
+latest_ver=$(latestNonRCVersion)
+beta_ver="0.0.1-beta1"
+if [ -z "$latest_ver" ]; then
+  info "Use ${YELLOW}$beta_ver${RESTORE} as the version number."
+else
+  beta_ver=$(increaseBetaVersion "$latest_ver")
+fi
+
+info "\nThe latest non-RC version is: ${CYAN}'$latest_ver'${RESTORE}"
+info "This beta version number should be: ${CYAN}'$beta_ver'${RESTORE}"
+
+remote_branch=$(git branch -r | awk '/'"$beta_ver"'-[0-9]+/ {print $1}')
+if [ ! "$remote_branch" ]; then
+  warning "Remote branch for beta version $beta_ver has not been created, which means you haven't started your beta release process. Run 'beta-branchoff.sh' to start the beta release process first."
+  exit 1
+fi
+
+info "Remote branch name: $remote_branch"
+
+latest_sha=$(git show $remote_branch --format=%h -s)
+notice "\nMake sure the latest commit SHA on '$remote_branch' is:"
+notice "${GREEN}$latest_sha${RESTORE}"
+notice "If it is not the beta release point you want, update the '$remote_branch' first."
+notice "Also make sure you have the permisison to push branch onto your $remote."
+
+read -e -p "Continue? [Y/n] " -n 1
+shouldContinue=${REPLY:=y}
+if [ ${shouldContinue,,} = n ]; then
+  info "Sure, bye."
+  exit 0
+fi
+
+stashLocalChanges
+
+beta_branch=$(git branch -r | awk '/'"$remote"'\/beta$/ {print $1}')
+if [ ! "$beta_branch" ]; then
+  error "Failed to find ${YELLOW}beta${RESTORE} branch on $remote, create it first before release."
+  exit 1
+fi
+
+info "Merge beta release commit to beta branch...\n"
+git checkout -B beta "$remote/beta"
+git merge -q --no-summary --no-ff $latest_sha -m "Merge beta release: $beta_ver" --signoff
+if [ $? -ne 0 ]; then
+  error "\nFailed to merge beta release changes $latest_sha onto beta, please take a look and merge it manually."
+  info "NOTICE: An interactive shell will be created to resolve the merge conflicts, please use ${YELLOW}git merge --continue${RESTORE} after conflicts get resolved, and ${YELLOW}exit${RESTORE} the interactive shell to continue.\n"
+  bash
+  notice "\nMerge conflicts resolved."
+fi
+info "Beta release changes merged into beta branch.\n"
+
+git push "$remote" beta:beta
+info "\n${GREEN}Done.${RESTORE}"
+
+info "\nCreating beta release: ${YELLOW}$beta_ver${RESTORE}...\n"
+hub release create -m "Beta Release: $beta_ver" -t "beta" $beta_ver
+git fetch "$remote"
+info "\n${GREEN}Released.${RESTORE}"
+
+info "\nRebase beta release commit back onto $remote/master branch..."
+local_branch=$(echo $remote_branch | awk -F '/' '{print $2}');
+git checkout -B "$local_branch" "$remote_branch"
+git rebase $remote/master
+if [ $? -ne 0 ]; then
+  error "\nFailed to rebase beta release changes $remote_branch onto master, please take a look and rebase it manually."
+  info "NOTICE: An interactive shell will be created to resolve the rebase conflicts, please use ${YELLOW}git rebase --continue${RESTORE} after conflicts get resolved, and ${YELLOW}exit${RESTORE} the interactive shell to continue.\n"
+  bash
+  notice "\nRebase conflicts resolved."
+fi
+info "Beta release changes rebased $remote_branch onto master."
+git push "$remote" "$local_branch":master
+info "\n${GREEN}Done.${RESTORE}"
+
+info "\nClean up local and remote beta release branches..."
+git checkout master
+git pull --rebase
+git branch -D "$local_branch"
+git push "$remote" :"$local_branch"
+info "\n${GREEN}Done.${RESTORE}"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -33,3 +33,98 @@ function warning () {
 function error () {
   echo -e "${RED}$*${RESTORE}"
 }
+
+function prepareWorkingDir () {
+  read -e -p "Your upstream git remote is? [origin]"
+  export remote=${REPLY:="origin"}
+
+  info "Fetching latest changes and prune ${LGREEN}$remote${RESTORE}..."
+  git fetch -p -t "$remote" || { error "It is not able to fetch codes from your $remote, check if there is any issue."; exit 1; }
+
+  git remote prune "$remote"
+  info "${GREEN}Done.${RESTORE}"
+}
+
+function isValidVersion () {
+  echo "$1" | awk '/^[0-9]+\.[0-9]+(\.[0-9]+){0,2}(-rc[0-9]+|-beta[0-9]+)?$/ {print $0}'
+}
+
+function isBetaVersion () {
+  echo "$1" | awk '/^[0-9]+\.[0-9]+(\.[0-9]+){0,2}-beta[0-9]+$/ {print $0}'
+}
+
+function isRCVersion () {
+  echo "$1" | awk '/^[0-9]+\.[0-9]+(\.[0-9]+){0,2}-rc[0-9]+$/ {print $0}'
+}
+
+function latestVersion () {
+  git tag -l | awk '/^0\.[0-9]+(\.[0-9]+){0,2}(-rc[0-9]+|-beta[0-9]+)?$/ { print $0 }' | sort -rV | head -n 1
+}
+
+function latestNonRCVersion () {
+  git tag -l | awk '/^0\.[0-9]+(\.[0-9]+){0,2}(-beta[0-9]+)?$/ { print $0 }' | sort -rV | head -n 1
+}
+
+function betaNumber () {
+  echo "$1" | awk -F 'beta' '{print $2}'
+}
+
+function rcNumber () {
+  echo "$1" | awk -F 'rc' '{print $2}'
+}
+
+function gitRepoModified () {
+  git status --short | awk '/^[ M][ M] / { print $0 }'
+}
+
+function stashLocalChanges () {
+  if [ "$(gitRepoModified)" ]; then
+    read -e -p "Your working directory is modified, stash it? [Y/n]" -n 1
+    shouldStash=${REPLY:=y}
+    if [ ${shouldStash,,} = y ]; then
+      git stash
+    else
+      info "Change ignored."
+    fi
+  fi
+}
+
+function increaseBetaVersion () {
+  if [ $(isRCVersion "$1") ]; then
+    # Unable to increase beta version number on a RC version, exit.
+    return 1
+  fi
+  if [ $(isBetaVersion "$1") ]; then
+    echo "$1" | awk -F 'beta' '{printf("%sbeta%d\n", $1, $2+1)}'
+  else
+    echo "$1" | awk -F '.' '/^([0-9]+\.){1,3}([0-9]+)$/ {
+      for(i=1;i<=NF;i++) {
+        if (i==NF) {
+          printf("%d-beta1\n", $i+1)
+        } else {
+          printf("%d.", $i)
+        }
+      }
+    }'
+  fi
+}
+
+function increaseRCVersion () {
+  if [ $(isBetaVersion "$1") ]; then
+    # Unable to increase rc version number on a beta version, exit.
+    return 1
+  fi
+  if [ $(isRCVersion "$1") ]; then
+    echo "$1" | awk -F 'rc' '{printf("%src%d\n", $1, $2+1)}'
+  else
+    echo "$1" | awk -F '.' '/^([0-9]+\.){1,3}([0-9]+)$/ {
+      for(i=1;i<=NF;i++) {
+        if (i==NF) {
+          printf("%d-rc1\n", $i+1)
+        } else {
+          printf("%d.", $i)
+        }
+      }
+    }'
+  fi
+}


### PR DESCRIPTION
The script beta-signoff.sh is used when you are ready to publish the
beta release out of the temporary beta branch created from
beta-branchoff.sh. It merges beta changes to 'beta' branch and publishes
a beta release using 'hub' command onto Github, a release tag will also
be tagged. The commits on temporary beta release branch will also be
rebased back to master branch after the release, you may also need to
resolve the merge / rebase conflicts if possible during the process.

Issue: #1431