### PR TITLE
[WEEX-575][Android] fix ListComponent pagingEnabled bug

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/list/BasicListComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/list/BasicListComponent.java
@@ -276,7 +276,6 @@ public abstract class BasicListComponent<T extends ViewGroup & ListComponentView
     recyclerViewBaseAdapter.setHasStableIds(true);
     bounceRecyclerView.setRecyclerViewBaseAdapter(recyclerViewBaseAdapter);
     bounceRecyclerView.setOverScrollMode(View.OVER_SCROLL_NEVER);
-    bounceRecyclerView.getInnerView().clearOnScrollListeners();
     bounceRecyclerView.getInnerView().addOnScrollListener(mViewOnScrollListener);
     if(getAttrs().get(Constants.Name.HAS_FIXED_SIZE) != null){
       boolean hasFixedSize = WXUtils.getBoolean(getAttrs().get(Constants.Name.HAS_FIXED_SIZE), false);


### PR DESCRIPTION
Do not call clearOnScrollListeners when create RecyclerView, because PagerSnapHelper will set OnScrollListener and need to rely on it.