### PR TITLE
[WEEX-593][iOS]image can not show correct borderRadius

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXImageComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXImageComponent.m
@@ -296,6 +296,16 @@ WX_EXPORT_METHOD(@selector(save:))
     return NO;
 }
 
+- (void)_resetNativeBorderRadius
+{
+    if (_borderTopLeftRadius == _borderTopRightRadius && _borderTopRightRadius == _borderBottomLeftRadius && _borderBottomLeftRadius == _borderBottomRightRadius)
+    {
+        _layer.cornerRadius = _borderBottomLeftRadius;
+        return;
+    }
+    [self _clipsToBounds];
+}
+
 - (BOOL)needsDrawRect
 {
     if (_isCompositingChild) {


### PR DESCRIPTION
bugfix about can not show correct borderRadius
you can see deme here:http://rax.alibaba-inc.com/playground/f52475b6-a7b6-4b8d-9293-16ebe803ba69