### PR TITLE
0.18.0 hotfix

### DIFF
--- a/SCRIPTS.md
+++ b/SCRIPTS.md
@@ -15,3 +15,6 @@ There are several scripts for end-user and developer.
 * `npm run clean`: clean both `examples/build/` and `test/build/`.
 * `npm run copy`: copy JS framework and examples into Android project.
 * `npm run lint`, `npm run test`, `npm run cover` and `npm run ci` are something quality assurance.
+
+
+

--- a/ios/sdk/WeexSDK/Sources/Component/WXEditComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXEditComponent.m
@@ -518,7 +518,11 @@ WX_EXPORT_METHOD(@selector(getSelectionRange:))
         NSUInteger rangeLength = range.length;
         
         NSUInteger newLength = oldLength - rangeLength + replacementLength;
-        
+        if (newLength <= oldLength) {
+            // deleting, we should allow delete
+            return YES;
+        }
+
         return newLength <= [_maxLength integerValue] ;
     }
     return YES;

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
@@ -197,7 +197,7 @@ typedef UITextView WXTextAreaView;
     self.placeHolderLabel.clipsToBounds = NO;
     CGRect newFrame = self.placeHolderLabel.frame;
     newFrame.size.height = ceil(expectedLabelSize.size.height);
-    newFrame.size.width = _textView.frame.size.width- CorrectX*2;
+    newFrame.size.width = _textView.frame.size.width - (_padding.left + _border.left + _padding.right + _border.right) -CorrectX*2;
     newFrame.origin.x = CorrectX + _padding.left + _border.left; // the cursor origin.x
     self.placeHolderLabel.frame = newFrame;
     self.placeHolderLabel.attributedText = attributedString;
@@ -220,11 +220,11 @@ typedef UITextView WXTextAreaView;
     [_textView setTextContainerInset:UIEdgeInsetsMake(_padding.top + _border.top,
                                                       _padding.left + _border.left,
                                                       _padding.bottom + _border.bottom,
-                                                      _border.right + _border.right)];
+                                                      _padding.right + _border.right)];
     
     //when textview update, placeHolderLabel update too
     CGRect newFrame = self.placeHolderLabel.frame;
-    newFrame.size.width = self.textView.frame.size.width - (_padding.left + _border.left) -CorrectX*2;
+    newFrame.size.width = self.textView.frame.size.width - (_padding.left + _border.left + _padding.right + _border.right) -CorrectX*2;
     newFrame.origin.x = CorrectX + _padding.left + _border.left; // the cursor origin.x
     newFrame.origin.y = _padding.top + _border.top;
     self.placeHolderLabel.frame = newFrame;

--- a/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXTextAreaComponent.m
@@ -185,6 +185,11 @@ typedef UITextView WXTextAreaView;
 
 -(void)setAttributedPlaceholder:(NSMutableAttributedString *)attributedString font:(UIFont *)font
 {
+    if ([_textView.text length] > 0) {
+        self.placeHolderLabel.text = @"";
+        return;
+    }
+
     if (self.placeholderColor) {
         [attributedString addAttribute:NSForegroundColorAttributeName value:self.placeholderColor range:NSMakeRange(0, self.placeholderString.length)];
         [attributedString addAttribute:NSFontAttributeName value:font range:NSMakeRange(0, self.placeholderString.length)];


### PR DESCRIPTION
in this WXCircleViewPager class ,when destroy we can use next code to call system gc better,when we used, the memory jump down quickly.
protected void unbindDrawables(View view) {
        if (view.getBackground() != null) {
            view.getBackground().setCallback(null);
        }
        if (view instanceof ViewGroup && !(view instanceof AdapterView)) {
            for (int i = 0; i < ((ViewGroup) view).getChildCount(); i++) {
                unbindDrawables(((ViewGroup) view).getChildAt(i));
            }
            ((ViewGroup) view).removeAllViews();
        }
    }