### PR TITLE
[WEEX-612][android] Fixed after input component default set  a string…

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/AbstractEditComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/AbstractEditComponent.java
@@ -348,6 +348,7 @@ public abstract class AbstractEditComponent extends WXComponent<WXEditText> {
         public void onTextChanged(CharSequence s, int start, int before, int count) {
           if (mIgnoreNextOnInputEvent) {
             mIgnoreNextOnInputEvent = false;
+            mBeforeText = s.toString();
             return;
           }
 


### PR DESCRIPTION
[WEEX-612] Fixed after input component default set a string on android platform, and then remove it, not trigger input event.
see more here https://issues.apache.org/jira/browse/WEEX-612

Bug:612
