### PR TITLE
[WEEX-634][Android] fix old performance record time

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/common/WXPerformance.java
+++ b/android/sdk/src/main/java/com/taobao/weex/common/WXPerformance.java
@@ -24,6 +24,7 @@ import com.taobao.weex.WXEnvironment;
 import com.taobao.weex.WXSDKInstance;
 import com.taobao.weex.WXSDKManager;
 import com.taobao.weex.performance.WXInstanceApm;
+import com.taobao.weex.utils.WXUtils;
 import com.taobao.weex.utils.WXViewUtils;
 
 import java.util.HashMap;
@@ -165,6 +166,8 @@ public class WXPerformance {
 
   @RestrictTo(RestrictTo.Scope.LIBRARY)
   public long renderTimeOrigin;
+
+  public long renderUnixTimeOrigin;
 
   public long fsRenderTime;
 
@@ -555,6 +558,7 @@ public class WXPerformance {
 
   public void beforeInstanceRender(String instanceId) {
     renderTimeOrigin = System.currentTimeMillis();
+    renderUnixTimeOrigin = WXUtils.getFixUnixTime();
   }
 
   public void afterInstanceDestroy(String instanceId) {

--- a/android/sdk/src/main/java/com/taobao/weex/performance/WXInstanceApm.java
+++ b/android/sdk/src/main/java/com/taobao/weex/performance/WXInstanceApm.java
@@ -276,17 +276,17 @@ public class WXInstanceApm {
             hasRecordFistInteractionView = true;
         }
 
-        long curTIme = WXUtils.getFixUnixTime();
+        long curTime = WXUtils.getFixUnixTime();
 
         if (BuildConfig.DEBUG){
             Log.d("wxapm", "screenComponent ["+targetComponent.getComponentType()+","+targetComponent.getRef()
-                +"], renderTime:"+ (curTIme -performanceRecord.renderTimeOrigin)
+                +"], renderTime:"+ (curTime -performanceRecord.renderUnixTimeOrigin)
                 +",style:"+targetComponent.getStyles()
                 +",attrs:"+targetComponent.getAttrs());
         }
 
-        performanceRecord.interactionTime = curTIme - performanceRecord.renderTimeOrigin;
-        onStageWithTime(KEY_PAGE_STAGES_INTERACTION,curTIme);
+        performanceRecord.interactionTime = curTime - performanceRecord.renderUnixTimeOrigin;
+        onStageWithTime(KEY_PAGE_STAGES_INTERACTION,curTime);
 
         updateDiffStats(KEY_PAGE_STATS_I_SCREEN_VIEW_COUNT, 1);
         updateMaxStats(KEY_PAGE_STATS_I_ALL_VIEW_COUNT, performanceRecord.localInteractionViewAddCount);


### PR DESCRIPTION
- record renderUnixTimeOrigin use `WXUtils.getFixUnixTime()` to replace `System.currentTimeMillis()`