### PR TITLE
[WEEX-648][iOS]native batch for dom operations generating from JavaScript

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.h
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.h
@@ -262,4 +262,18 @@ void WXPerformBlockSyncOnComponentThread(void (^block)(void));
  */
 - (void)enumerateComponentsUsingBlock:(void (^)(WXComponent *, BOOL *stop))block;
 
+#pragma mark batch mark
+
+/**
+ a start native batch tag for a group of UI operation  , company with performBatchEnd
+ @see performBatchEnd
+ */
+- (void)performBatchBegin;
+
+/**
+ an end native batch tag for a group of UI operation, company with performBatchBegin
+ @see performBatchBegin
+ */
+- (void)performBatchEnd;
+
 @end

--- a/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.h
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.h
@@ -265,13 +265,13 @@ void WXPerformBlockSyncOnComponentThread(void (^block)(void));
 #pragma mark batch mark
 
 /**
- a start native batch tag for a group of UI operation  , company with performBatchEnd
+ a start native batch tag for a group of UI operations, company with performBatchEnd
  @see performBatchEnd
  */
 - (void)performBatchBegin;
 
 /**
- an end native batch tag for a group of UI operation, company with performBatchBegin
+ an end native batch tag for a group of UI operations, company with performBatchBegin
  @see performBatchBegin
  */
 - (void)performBatchEnd;

--- a/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.mm
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.mm
@@ -1018,14 +1018,15 @@ static NSThread *WXComponentThread;
     }
     
     if (mismatchBeginIndex > 0) {
-        NSArray<dispatch_block_t> *blocks = nil;
-        blocks = [_uiTaskQueue subarrayWithRange:NSMakeRange(0, mismatchBeginIndex)];
+        NSArray<dispatch_block_t> *blocks = [_uiTaskQueue subarrayWithRange:NSMakeRange(0, mismatchBeginIndex)];
         [_uiTaskQueue removeObjectsInRange:NSMakeRange(0, mismatchBeginIndex)];
-        dispatch_async(dispatch_get_main_queue(), ^{
-            for(dispatch_block_t block in blocks) {
-                block();
-            }
-        });
+        if (blocks.count) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                for(dispatch_block_t block in blocks) {
+                    block();
+                }
+            });
+        }
     }
 }
 

--- a/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.mm
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.mm
@@ -44,7 +44,7 @@
 static NSThread *WXComponentThread;
 
 #define WXAssertComponentExist(component)  WXAssert(component, @"component not exists")
-#define MAX_DROP_FRAME_FOR_BATCH   20
+#define MAX_DROP_FRAME_FOR_BATCH   200
 
 @implementation WXComponentManager
 {

--- a/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.mm
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.mm
@@ -995,6 +995,8 @@ static NSThread *WXComponentThread;
     NSInteger mismatchBeginIndex = _uiTaskQueue.count;
     for (NSInteger i = _uiTaskQueue.count - 1;i >= 0;i --) {
         if (_uiTaskQueue[i] == WXPerformUITaskBatchEndBlock) {
+            _syncUITaskCount = 0;
+            // clear when find the matches for end and begin tag
             break;
         }
         if (_uiTaskQueue[i] == WXPerformUITaskBatchBeginBlock) {
@@ -1005,11 +1007,12 @@ static NSThread *WXComponentThread;
     
     NSArray<dispatch_block_t> *blocks = nil;
     if (mismatchBeginIndex == _uiTaskQueue.count) {
-        // we find end tag or no end or begin
+        // here we get end tag or there are not begin and end directives
     } else {
         _syncUITaskCount ++;
         // we only find begin tag but missing end tag,
         if (_syncUITaskCount > (MAX_DROP_FRAME_FOR_BATCH)) {
+            // when the wait times come to MAX_DROP_FRAME_FOR_BATCH, we will pop all the stashed operation for user experience.
             mismatchBeginIndex = _uiTaskQueue.count;
             _syncUITaskCount = 0;
         }

--- a/ios/sdk/WeexSDK/Sources/Module/WXDomModule.m
+++ b/ios/sdk/WeexSDK/Sources/Module/WXDomModule.m
@@ -55,6 +55,8 @@ WX_EXPORT_METHOD(@selector(updateAttrs:attrs:))
 WX_EXPORT_METHOD(@selector(addRule:rule:))
 WX_EXPORT_METHOD(@selector(getComponentRect:callback:))
 WX_EXPORT_METHOD(@selector(updateComponentData:componentData:callback:))
+WX_EXPORT_METHOD(@selector(beginBatchMark))
+WX_EXPORT_METHOD(@selector(endBatchMark))
 
 - (void)performBlockOnComponentManager:(void(^)(WXComponentManager *))block
 {
@@ -80,6 +82,20 @@ WX_EXPORT_METHOD(@selector(updateComponentData:componentData:callback:))
     WXPerformBlockOnComponentThread(^{
         block();
     });
+}
+
+- (void)beginBatchMark
+{
+    [self performBlockOnComponentManager:^(WXComponentManager *manager) {
+        [manager performBatchBegin];
+    }];
+}
+
+- (void)endBatchMark
+{
+    [self performBlockOnComponentManager:^(WXComponentManager * manager) {
+        [manager performBatchEnd];
+    }];
 }
 
 - (NSThread *)targetExecuteThread


### PR DESCRIPTION
introduce a native batch for dom operations generating from JavaScript
  wrap a series of dom operations with beginBatch and endBatch directives, when every V-sync signal comes, we try to ensure that the operations between beginBatch and endBatch can be performed in current V-sync, this policy can drop frames maybe, for our policy dropping frames, we only allow 20 frames at most.

see Android policy pull request #1647 

feature:648