### PR TITLE
[WEEX-648][Android]native batch for dom operations generating from JavaScript

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/WXRenderManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/WXRenderManager.java
@@ -50,7 +50,7 @@ public class WXRenderManager {
   private volatile ConcurrentHashMap<String, RenderContextImpl> mRenderContext;
   private WXRenderHandler mWXRenderHandler;
   private ArrayList<Map<String,Object>> mBatchActions = new ArrayList<>();
-  private final int MAX_DROP_FRAME_NATIVE_BATCH = 20;
+  private final int MAX_DROP_FRAME_NATIVE_BATCH = 200;
   private final static  String sKeyAction = "Action";
   private static int nativeBatchTimes = 0;
 

--- a/android/sdk/src/main/java/com/taobao/weex/ui/WXRenderManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/WXRenderManager.java
@@ -30,11 +30,13 @@ import com.taobao.weex.common.WXThread;
 import com.taobao.weex.dom.RenderContext;
 import com.taobao.weex.performance.WXInstanceApm;
 import com.taobao.weex.ui.action.BasicGraphicAction;
+import com.taobao.weex.ui.action.GraphicActionBatchAction;
 import com.taobao.weex.ui.component.WXComponent;
 import com.taobao.weex.utils.WXExceptionUtils;
 import com.taobao.weex.utils.WXUtils;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -47,6 +49,10 @@ public class WXRenderManager {
 
   private volatile ConcurrentHashMap<String, RenderContextImpl> mRenderContext;
   private WXRenderHandler mWXRenderHandler;
+  private ArrayList<Map<String,Object>> mBatchActions = new ArrayList<>();
+  private final int MAX_DROP_FRAME_NATIVE_BATCH = 20;
+  private final static  String sKeyAction = "Action";
+  private static int nativeBatchTimes = 0;
 
   public WXRenderManager() {
     mRenderContext = new ConcurrentHashMap<>();
@@ -116,11 +122,43 @@ public class WXRenderManager {
     }
   }
 
+  private void postAllStashedGraphicAction(final String instanceId,final BasicGraphicAction action) {
+      ArrayList<Map<String, Object>> tmpList = new ArrayList<>(mBatchActions);
+      this.mBatchActions.clear();
+      ArrayList<BasicGraphicAction> actions = new ArrayList<>(tmpList.size());
+      for (int i = 0 ; i < tmpList.size(); i ++) {
+          Map<String, Object> item = tmpList.get(i);
+          BasicGraphicAction tmpAction = (BasicGraphicAction)item.get(sKeyAction);
+          if (tmpAction.mActionType == BasicGraphicAction.ActionTypeBatchBegin || tmpAction.mActionType == BasicGraphicAction.ActionTypeBatchEnd) {
+              continue;
+          }
+          actions.add(tmpAction);
+      }
+      nativeBatchTimes = 0;
+      postGraphicAction(instanceId, new GraphicActionBatchAction(action.getWXSDKIntance(),action.getRef(), actions));
+  }
+
   public void postGraphicAction(final String instanceId, final BasicGraphicAction action) {
     final RenderContextImpl renderContext = mRenderContext.get(instanceId);
     if (renderContext == null) {
       return;
     }
+
+    if (action.mActionType == BasicGraphicAction.ActionTypeBatchEnd) {
+        postAllStashedGraphicAction(instanceId,action);
+        return;
+    } else if (action.mActionType == BasicGraphicAction.ActionTypeBatchBegin || this.mBatchActions.size() > 0 ) {
+        nativeBatchTimes ++ ;
+        if (nativeBatchTimes > MAX_DROP_FRAME_NATIVE_BATCH) {
+            postAllStashedGraphicAction(instanceId,action);
+        } else {
+            HashMap<String, Object> item = new HashMap<>(1);
+            item.put(sKeyAction, action);
+            mBatchActions.add(item);
+            return;
+        }
+    }
+
     mWXRenderHandler.post(instanceId, action);
   }
 

--- a/android/sdk/src/main/java/com/taobao/weex/ui/action/BasicGraphicAction.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/action/BasicGraphicAction.java
@@ -28,6 +28,11 @@ public abstract class BasicGraphicAction implements IExecutable, Runnable {
 
   private WXSDKInstance mInstance;
   private final String mRef;
+  public int mActionType = ActionTypeNormal;
+  public static final int ActionTypeBatchBegin = 1;
+  public static final int ActionTypeBatchEnd = 2;
+  public static final int ActionTypeNormal = 0;
+
 
   public BasicGraphicAction(WXSDKInstance instance, String ref) {
     this.mInstance = instance;

--- a/android/sdk/src/main/java/com/taobao/weex/ui/action/GraphicActionBatchAction.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/action/GraphicActionBatchAction.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.taobao.weex.ui.action;
+
+import com.taobao.weex.WXSDKInstance;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GraphicActionBatchAction extends BasicGraphicAction {
+    private List<BasicGraphicAction> mActions;
+
+    public GraphicActionBatchAction(WXSDKInstance instance, String ref, List<BasicGraphicAction> mActions) {
+        super(instance, ref);
+        this.mActions = new ArrayList<>(mActions);
+    }
+
+    @Override
+    public void executeAction() {
+        for (int i = 0;i < mActions.size();i ++) {
+            mActions.get(i).executeAction();
+        }
+    }
+}

--- a/android/sdk/src/main/java/com/taobao/weex/ui/action/GraphicActionBatchBegin.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/action/GraphicActionBatchBegin.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.taobao.weex.ui.action;
+
+import com.taobao.weex.WXSDKInstance;
+
+public class GraphicActionBatchBegin extends BasicGraphicAction {
+    public GraphicActionBatchBegin(WXSDKInstance instance, String ref) {
+        super(instance, ref);
+        this.mActionType = ActionTypeBatchBegin;
+    }
+
+    @Override
+    public void executeAction() {
+
+    }
+}

--- a/android/sdk/src/main/java/com/taobao/weex/ui/action/GraphicActionBatchEnd.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/action/GraphicActionBatchEnd.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.taobao.weex.ui.action;
+
+import com.taobao.weex.WXSDKInstance;
+
+public class GraphicActionBatchEnd extends BasicGraphicAction {
+    public GraphicActionBatchEnd(WXSDKInstance instance, String ref) {
+        super(instance, ref);
+        this.mActionType = ActionTypeBatchEnd;
+    }
+
+    @Override
+    public void executeAction() {
+
+    }
+}

--- a/android/sdk/src/main/java/com/taobao/weex/ui/module/WXDomModule.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/module/WXDomModule.java
@@ -27,6 +27,8 @@ import com.taobao.weex.dom.binding.JSONUtils;
 import com.taobao.weex.ui.action.ActionAddRule;
 import com.taobao.weex.ui.action.ActionGetComponentRect;
 import com.taobao.weex.ui.action.ActionInvokeMethod;
+import com.taobao.weex.ui.action.GraphicActionBatchBegin;
+import com.taobao.weex.ui.action.GraphicActionBatchEnd;
 import com.taobao.weex.ui.action.GraphicActionScrollToElement;
 import com.taobao.weex.ui.action.UpdateComponentDataAction;
 import com.taobao.weex.utils.WXLogUtils;
@@ -50,11 +52,14 @@ public final class WXDomModule extends WXModule {
 
   public static final String UPDATE_COMPONENT_DATA = "updateComponentData";
 
+  public static final String BATCH_BEGIN = "beginBatchMark";
+  public static final String BATCH_END = "endBatchMark";
+
   /**
    * Methods expose to js. Every method which will be called in js should add to this array.
    */
   public static final String[] METHODS = {SCROLL_TO_ELEMENT, ADD_RULE, GET_COMPONENT_RECT,
-      INVOKE_METHOD};
+      INVOKE_METHOD, BATCH_BEGIN, BATCH_END};
 
   public WXDomModule(WXSDKInstance instance){
     mWXSDKInstance = instance;
@@ -118,6 +123,16 @@ public final class WXDomModule extends WXModule {
           }
           new UpdateComponentDataAction(mWXSDKInstance, args.getString(0), JSONUtils.toJSON(args.get(1)), args.getString(2)).executeAction();
           break;
+        case BATCH_BEGIN: {
+          String ref = args.size() >= 1 ? args.getString(0) : null;
+          new GraphicActionBatchBegin(mWXSDKInstance, ref).executeActionOnRender();
+          break;
+        }
+        case BATCH_END: {
+          String ref = args.size() >= 1 ? args.getString(0) : null;
+          new GraphicActionBatchEnd(mWXSDKInstance, ref).executeActionOnRender();
+          break;
+        }
         default:
           WXLogUtils.e("Unknown dom action.");
           break;

--- a/android/sdk/src/main/java/com/taobao/weex/ui/module/WXDomModule.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/module/WXDomModule.java
@@ -124,6 +124,9 @@ public final class WXDomModule extends WXModule {
           new UpdateComponentDataAction(mWXSDKInstance, args.getString(0), JSONUtils.toJSON(args.get(1)), args.getString(2)).executeAction();
           break;
         case BATCH_BEGIN: {
+          if(args == null){
+            return null;
+          }
           String ref = args.size() >= 1 ? args.getString(0) : null;
           new GraphicActionBatchBegin(mWXSDKInstance, ref).executeActionOnRender();
           break;


### PR DESCRIPTION
introduce a native batch for dom operations generating from JavaScript
wrap a series of dom operations with beginBatch and endBatch directives, when every V-sync signal comes, we try to ensure that the operations between beginBatch and endBatch can be performed in current V-sync, this policy can drop frames maybe, for our policy dropping frames, we only allow 20 frames at most.
see iOS pull request https://github.com/apache/incubator-weex/pull/1644

feature:648