### PR TITLE
[iOS] treat 750 as container width not device width when rotated or splited in ipad

### DIFF
--- a/ios/playground/WeexDemo/WXDemoViewController.m
+++ b/ios/playground/WeexDemo/WXDemoViewController.m
@@ -49,7 +49,7 @@
 {
     if (self = [super init]) {
     }
-    
+
     return self;
 }
 

--- a/ios/sdk/WeexSDK/Sources/Bridge/WXCoreBridge.h
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXCoreBridge.h
@@ -153,6 +153,8 @@ namespace WeexCore
                  isWidthWrapContent:(BOOL)isWidthWrapContent
                 isHeightWrapContent:(BOOL)isHeightWrapContent;
 
++ (void)setDeviceWidth:(CGFloat)width;
+
 + (void)setViewportWidth:(NSString*)pageId width:(CGFloat)width;
 
 + (void)layoutPage:(NSString*)pageId forced:(BOOL)forced;

--- a/ios/sdk/WeexSDK/Sources/Bridge/WXCoreBridge.mm
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXCoreBridge.mm
@@ -893,6 +893,10 @@ static WeexCore::ScriptBridge* jsBridge = nullptr;
     }
 }
 
++ (void)setDeviceWidth:(CGFloat)width {
+    WXCoreEnvironment::getInstance()->SetDeviceWidth(std::to_string(width));
+}
+
 + (void)setViewportWidth:(NSString*)pageId width:(CGFloat)width
 {
     if (platformBridge) {

--- a/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.mm
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXComponentManager.mm
@@ -173,6 +173,7 @@ static NSThread *WXComponentThread;
 {
     WXAssertComponentThread();
     CGSize size = _weexInstance.frame.size;
+    [WXCoreBridge setDeviceWidth:size.width];
     [WXCoreBridge setDefaultDimensionIntoRoot:_weexInstance.instanceId
                                         width:size.width height:size.height
                            isWidthWrapContent:size.width == 0.0f isHeightWrapContent:size.height == 0.0f];

--- a/ios/sdk/WeexSDK/Sources/Utility/WXUtility.m
+++ b/ios/sdk/WeexSDK/Sources/Utility/WXUtility.m
@@ -731,7 +731,8 @@ CGFloat WXFloorPixelValue(CGFloat value)
 + (CGSize)portraitScreenSize
 {
     if ([[UIDevice currentDevice].model isEqualToString:@"iPad"]) {
-        return [UIScreen mainScreen].bounds.size;
+        CGRect windowRect = [UIApplication sharedApplication].keyWindow.bounds;
+        return windowRect.size;
     }
     static CGSize portraitScreenSize;
     static dispatch_once_t onceToken;
@@ -747,7 +748,8 @@ CGFloat WXFloorPixelValue(CGFloat value)
 + (CGFloat)defaultPixelScaleFactor
 {
     if ([[UIDevice currentDevice].model isEqualToString:@"iPad"]) {
-        return [self portraitScreenSize].width / WXDefaultScreenWidth;
+        CGRect windowRect = [UIApplication sharedApplication].keyWindow.bounds;
+        return windowRect.size.width / WXDefaultScreenWidth;
     }
     static CGFloat defaultScaleFactor;
     static dispatch_once_t onceToken;


### PR DESCRIPTION
If a component's width is set to 750, weex will calculate it's width as the device width, however when you put weex in ipad, the size of weex container don't usually equal to device width ( e.g. split view ), and also the device width didn't update after rotation. This PR solved the problem.