### PR TITLE
Fix bug:  register service method needs a callback

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.h
+++ b/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.h
@@ -82,7 +82,7 @@
  * @param completion completion callback
  *
  */
-+ (void)registerService:(NSString *)name withScript:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void(^)(void))completion;
++ (void)registerService:(NSString *)name withScript:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void(^)(BOOL result))completion;
 
 /**
  * @abstract Registers a component for a given name, options and js url
@@ -96,7 +96,7 @@
  * @param completion completion callback
  *
  */
-+ (void)registerService:(NSString *)name withScriptUrl:(NSURL *)serviceScriptUrl WithOptions:(NSDictionary *)options completion:(void(^)(void))completion;
++ (void)registerService:(NSString *)name withScriptUrl:(NSURL *)serviceScriptUrl WithOptions:(NSDictionary *)options completion:(void(^)(BOOL result))completion;
 
 /**
  * @abstract Registers a component for a given name, options and js code

--- a/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.m
+++ b/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.m
@@ -152,12 +152,12 @@
 
 
 # pragma mark Service Register
-+ (void)registerService:(NSString *)name withScript:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void (^)(void))completion
++ (void)registerService:(NSString *)name withScript:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void (^)(BOOL))completion
 {
     [[WXSDKManager bridgeMgr] registerService:name withService:serviceScript withOptions:options completion:completion];
 }
 
-+ (void)registerService:(NSString *)name withScriptUrl:(NSURL *)serviceScriptUrl WithOptions:(NSDictionary *)options completion:(void (^)(void))completion
++ (void)registerService:(NSString *)name withScriptUrl:(NSURL *)serviceScriptUrl WithOptions:(NSDictionary *)options completion:(void (^)(BOOL))completion
 {
     [[WXSDKManager bridgeMgr] registerService:name withServiceUrl:serviceScriptUrl withOptions:options completion:completion];
 }

--- a/ios/sdk/WeexSDK/Sources/Manager/WXBridgeManager.h
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXBridgeManager.h
@@ -92,7 +92,7 @@ extern void WXPerformBlockOnBridgeThread(void (^block)(void));
  *  @param options   :   service options
  *  @param completion   :   completion callback
  **/
-- (void)registerService:(NSString *)name withService:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void(^)(void))completion;
+- (void)registerService:(NSString *)name withService:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void(^)(BOOL result))completion;
 
 
 /**
@@ -103,7 +103,7 @@ extern void WXPerformBlockOnBridgeThread(void (^block)(void));
  *  @param completion   :   completion callback
  **/
 
--(void)registerService:(NSString *)name withServiceUrl:(NSURL *)serviceScriptUrl withOptions:(NSDictionary *)options completion:(void(^)(void))completion;
+-(void)registerService:(NSString *)name withServiceUrl:(NSURL *)serviceScriptUrl withOptions:(NSDictionary *)options completion:(void(^)(BOOL result))completion;
 
 /**
  *  Unregister JS service Script

--- a/ios/sdk/WeexSDK/Sources/Manager/WXBridgeManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXBridgeManager.m
@@ -255,9 +255,13 @@ void WXPerformBlockSyncOnBridgeThread(void (^block) (void))
     return value;
 }
 
--(void)registerService:(NSString *)name withServiceUrl:(NSURL *)serviceScriptUrl withOptions:(NSDictionary *)options completion:(void (^)(void))completion
+-(void)registerService:(NSString *)name withServiceUrl:(NSURL *)serviceScriptUrl withOptions:(NSDictionary *)options completion:(void (^)(BOOL))completion
 {
-    if (!name || !serviceScriptUrl || !options) return;
+    if (!name || !serviceScriptUrl || !options) {
+        if (completion) completion(NO);
+        return;
+    }
+    
     __weak typeof(self) weakSelf = self;
     WXResourceRequest *request = [WXResourceRequest requestWithURL:serviceScriptUrl resourceType:WXResourceTypeServiceBundle referrer:@"" cachePolicy:NSURLRequestUseProtocolCachePolicy];
     WXResourceLoader *serviceBundleLoader = [[WXResourceLoader alloc] initWithRequest:request];;
@@ -269,14 +273,18 @@ void WXPerformBlockSyncOnBridgeThread(void (^block) (void))
     
     serviceBundleLoader.onFailed = ^(NSError *loadError) {
         WXLogError(@"No script URL found");
+        if (completion) completion(NO);
     };
     
     [serviceBundleLoader start];
 }
 
-- (void)registerService:(NSString *)name withService:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void (^)(void))completion
+- (void)registerService:(NSString *)name withService:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void (^)(BOOL))completion
 {
-    if (!name || !serviceScript || !options) return;
+    if (!name || !serviceScript || !options) {
+        if (completion) completion(NO);
+        return;
+    }
     
     NSString *script = [WXServiceFactory registerServiceScript:name withRawScript:serviceScript withOptions:options];
     
@@ -285,7 +293,7 @@ void WXPerformBlockSyncOnBridgeThread(void (^block) (void))
         // save it when execute
         [WXDebugTool cacheJsService:name withScript:serviceScript withOptions:options];
         [weakSelf.bridgeCtx executeJsService:script withName:name];
-        if (completion) completion();
+        if (completion) completion(YES);
     });
 }
 


### PR DESCRIPTION
The operation of registering service is in a child thread named jsthread.  We must render `page js` after downloaded `js service file` and make sure it’s executed. So the register service method need a callback. In this callback, we render the `page js`.

You can reproduce this bug, If you try to register a large size of  js service file.

中文解释：
由于页面中用到了js service文件中的模块，所以我在iOS中先调用`register service`再调用`render page`，以确保页面加载前js service已经注册进来。
但是当我注册了一个1.8M大小的js-service文件，我发现页面加载失败了。查看sdk源码发现`register service`内部执行js的过程是放在子线程进行的，所以我`render page`很可能会晚于`register service`。
所以，`register service`方法需要支持回调，这样我们在回调中再去`render page`就不会出现页面加载出来但是`register service`还没执行完的情况了。

