### PR TITLE
[iOS]Fix bug: register service method needs a callback

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.h
+++ b/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.h
@@ -79,8 +79,10 @@
  *
  * @param serviceScript service js code to invoke
  *
+ * @param completion completion callback
+ *
  */
-+ (void)registerService:(NSString *)name withScript:(NSString *)serviceScript withOptions:(NSDictionary *)options;
++ (void)registerService:(NSString *)name withScript:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void(^)(void))completion;
 
 /**
  * @abstract Registers a component for a given name, options and js url
@@ -91,8 +93,10 @@
  *
  * @param serviceScriptUrl The service url to register
  *
+ * @param completion completion callback
+ *
  */
-+ (void)registerService:(NSString *)name withScriptUrl:(NSURL *)serviceScriptUrl WithOptions:(NSDictionary *)options;
++ (void)registerService:(NSString *)name withScriptUrl:(NSURL *)serviceScriptUrl WithOptions:(NSDictionary *)options completion:(void(^)(void))completion;
 
 /**
  * @abstract Registers a component for a given name, options and js code

--- a/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.h
+++ b/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.h
@@ -82,7 +82,7 @@
  * @param completion completion callback
  *
  */
-+ (void)registerService:(NSString *)name withScript:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void(^)(void))completion;
++ (void)registerService:(NSString *)name withScript:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void(^)(BOOL result))completion;
 
 /**
  * @abstract Registers a component for a given name, options and js url
@@ -96,7 +96,7 @@
  * @param completion completion callback
  *
  */
-+ (void)registerService:(NSString *)name withScriptUrl:(NSURL *)serviceScriptUrl WithOptions:(NSDictionary *)options completion:(void(^)(void))completion;
++ (void)registerService:(NSString *)name withScriptUrl:(NSURL *)serviceScriptUrl WithOptions:(NSDictionary *)options completion:(void(^)(BOOL result))completion;
 
 /**
  * @abstract Registers a component for a given name, options and js code

--- a/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.m
+++ b/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.m
@@ -152,14 +152,14 @@
 
 
 # pragma mark Service Register
-+ (void)registerService:(NSString *)name withScript:(NSString *)serviceScript withOptions:(NSDictionary *)options
++ (void)registerService:(NSString *)name withScript:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void (^)(void))completion
 {
-    [[WXSDKManager bridgeMgr] registerService:name withService:serviceScript withOptions:options];
+    [[WXSDKManager bridgeMgr] registerService:name withService:serviceScript withOptions:options completion:completion];
 }
 
-+ (void)registerService:(NSString *)name withScriptUrl:(NSURL *)serviceScriptUrl WithOptions:(NSDictionary *)options
++ (void)registerService:(NSString *)name withScriptUrl:(NSURL *)serviceScriptUrl WithOptions:(NSDictionary *)options completion:(void (^)(void))completion
 {
-    [[WXSDKManager bridgeMgr] registerService:name withServiceUrl:serviceScriptUrl withOptions:options];
+    [[WXSDKManager bridgeMgr] registerService:name withServiceUrl:serviceScriptUrl withOptions:options completion:completion];
 }
 
 + (void)unregisterService:(NSString *)name
@@ -339,7 +339,7 @@ static NSDictionary *_customEnvironment;
         NSString *serviceName = [service objectForKey:@"name"];
         NSString *serviceScript = [service objectForKey:@"script"];
         NSDictionary *serviceOptions = [service objectForKey:@"options"];
-        [WXSDKEngine registerService:serviceName withScript:serviceScript withOptions:serviceOptions];
+        [WXSDKEngine registerService:serviceName withScript:serviceScript withOptions:serviceOptions completion:nil];
     }
 }
 

--- a/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.m
+++ b/ios/sdk/WeexSDK/Sources/Engine/WXSDKEngine.m
@@ -152,12 +152,12 @@
 
 
 # pragma mark Service Register
-+ (void)registerService:(NSString *)name withScript:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void (^)(void))completion
++ (void)registerService:(NSString *)name withScript:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void (^)(BOOL))completion
 {
     [[WXSDKManager bridgeMgr] registerService:name withService:serviceScript withOptions:options completion:completion];
 }
 
-+ (void)registerService:(NSString *)name withScriptUrl:(NSURL *)serviceScriptUrl WithOptions:(NSDictionary *)options completion:(void (^)(void))completion
++ (void)registerService:(NSString *)name withScriptUrl:(NSURL *)serviceScriptUrl WithOptions:(NSDictionary *)options completion:(void (^)(BOOL))completion
 {
     [[WXSDKManager bridgeMgr] registerService:name withServiceUrl:serviceScriptUrl withOptions:options completion:completion];
 }

--- a/ios/sdk/WeexSDK/Sources/Manager/WXBridgeManager.h
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXBridgeManager.h
@@ -90,8 +90,9 @@ extern void WXPerformBlockOnBridgeThread(void (^block)(void));
  *  @param name      :   service name
  *  @param serviceScript    :   script code
  *  @param options   :   service options
+ *  @param completion   :   completion callback
  **/
-- (void)registerService:(NSString *)name withService:(NSString *)serviceScript withOptions:(NSDictionary *)options;
+- (void)registerService:(NSString *)name withService:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void(^)(void))completion;
 
 
 /**
@@ -99,9 +100,10 @@ extern void WXPerformBlockOnBridgeThread(void (^block)(void));
  *  @param name         :   service name
  *  @param serviceScriptUrl    :   script url
  *  @param options      :   service options
+ *  @param completion   :   completion callback
  **/
 
--(void)registerService:(NSString *)name withServiceUrl:(NSURL *)serviceScriptUrl withOptions:(NSDictionary *)options;
+-(void)registerService:(NSString *)name withServiceUrl:(NSURL *)serviceScriptUrl withOptions:(NSDictionary *)options completion:(void(^)(void))completion;
 
 /**
  *  Unregister JS service Script

--- a/ios/sdk/WeexSDK/Sources/Manager/WXBridgeManager.h
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXBridgeManager.h
@@ -92,7 +92,7 @@ extern void WXPerformBlockOnBridgeThread(void (^block)(void));
  *  @param options   :   service options
  *  @param completion   :   completion callback
  **/
-- (void)registerService:(NSString *)name withService:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void(^)(void))completion;
+- (void)registerService:(NSString *)name withService:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void(^)(BOOL result))completion;
 
 
 /**
@@ -103,7 +103,7 @@ extern void WXPerformBlockOnBridgeThread(void (^block)(void));
  *  @param completion   :   completion callback
  **/
 
--(void)registerService:(NSString *)name withServiceUrl:(NSURL *)serviceScriptUrl withOptions:(NSDictionary *)options completion:(void(^)(void))completion;
+-(void)registerService:(NSString *)name withServiceUrl:(NSURL *)serviceScriptUrl withOptions:(NSDictionary *)options completion:(void(^)(BOOL result))completion;
 
 /**
  *  Unregister JS service Script

--- a/ios/sdk/WeexSDK/Sources/Manager/WXBridgeManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXBridgeManager.m
@@ -255,7 +255,7 @@ void WXPerformBlockSyncOnBridgeThread(void (^block) (void))
     return value;
 }
 
--(void)registerService:(NSString *)name withServiceUrl:(NSURL *)serviceScriptUrl withOptions:(NSDictionary *)options
+-(void)registerService:(NSString *)name withServiceUrl:(NSURL *)serviceScriptUrl withOptions:(NSDictionary *)options completion:(void (^)(void))completion
 {
     if (!name || !serviceScriptUrl || !options) return;
     __weak typeof(self) weakSelf = self;
@@ -264,7 +264,7 @@ void WXPerformBlockSyncOnBridgeThread(void (^block) (void))
     serviceBundleLoader.onFinished = ^(WXResourceResponse *response, NSData *data) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         NSString *jsServiceString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-        [strongSelf registerService:name withService:jsServiceString withOptions:options];
+        [strongSelf registerService:name withService:jsServiceString withOptions:options completion:completion];
     };
     
     serviceBundleLoader.onFailed = ^(NSError *loadError) {
@@ -274,7 +274,7 @@ void WXPerformBlockSyncOnBridgeThread(void (^block) (void))
     [serviceBundleLoader start];
 }
 
-- (void)registerService:(NSString *)name withService:(NSString *)serviceScript withOptions:(NSDictionary *)options
+- (void)registerService:(NSString *)name withService:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void (^)(void))completion
 {
     if (!name || !serviceScript || !options) return;
     
@@ -285,6 +285,7 @@ void WXPerformBlockSyncOnBridgeThread(void (^block) (void))
         // save it when execute
         [WXDebugTool cacheJsService:name withScript:serviceScript withOptions:options];
         [weakSelf.bridgeCtx executeJsService:script withName:name];
+        if (completion) completion();
     });
 }
 

--- a/ios/sdk/WeexSDK/Sources/Manager/WXBridgeManager.m
+++ b/ios/sdk/WeexSDK/Sources/Manager/WXBridgeManager.m
@@ -255,9 +255,13 @@ void WXPerformBlockSyncOnBridgeThread(void (^block) (void))
     return value;
 }
 
--(void)registerService:(NSString *)name withServiceUrl:(NSURL *)serviceScriptUrl withOptions:(NSDictionary *)options completion:(void (^)(void))completion
+-(void)registerService:(NSString *)name withServiceUrl:(NSURL *)serviceScriptUrl withOptions:(NSDictionary *)options completion:(void (^)(BOOL))completion
 {
-    if (!name || !serviceScriptUrl || !options) return;
+    if (!name || !serviceScriptUrl || !options) {
+        if (completion) completion(NO);
+        return;
+    }
+    
     __weak typeof(self) weakSelf = self;
     WXResourceRequest *request = [WXResourceRequest requestWithURL:serviceScriptUrl resourceType:WXResourceTypeServiceBundle referrer:@"" cachePolicy:NSURLRequestUseProtocolCachePolicy];
     WXResourceLoader *serviceBundleLoader = [[WXResourceLoader alloc] initWithRequest:request];;
@@ -269,14 +273,18 @@ void WXPerformBlockSyncOnBridgeThread(void (^block) (void))
     
     serviceBundleLoader.onFailed = ^(NSError *loadError) {
         WXLogError(@"No script URL found");
+        if (completion) completion(NO);
     };
     
     [serviceBundleLoader start];
 }
 
-- (void)registerService:(NSString *)name withService:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void (^)(void))completion
+- (void)registerService:(NSString *)name withService:(NSString *)serviceScript withOptions:(NSDictionary *)options completion:(void (^)(BOOL))completion
 {
-    if (!name || !serviceScript || !options) return;
+    if (!name || !serviceScript || !options) {
+        if (completion) completion(NO);
+        return;
+    }
     
     NSString *script = [WXServiceFactory registerServiceScript:name withRawScript:serviceScript withOptions:options];
     
@@ -285,7 +293,7 @@ void WXPerformBlockSyncOnBridgeThread(void (^block) (void))
         // save it when execute
         [WXDebugTool cacheJsService:name withScript:serviceScript withOptions:options];
         [weakSelf.bridgeCtx executeJsService:script withName:name];
-        if (completion) completion();
+        if (completion) completion(YES);
     });
 }
 


### PR DESCRIPTION
The operation of registering service is in a child thread named jsthread. We must render page js after downloaded js service file and make sure it’s executed. So the register service method need a callback. In this callback, we render the page js.

You can reproduce this bug, If you try to register a large size of js service file.

中文解释：
由于页面中用到了js service文件中的模块，所以我在iOS中先调用register service再调用render page，以确保页面加载前js service已经注册进来。
但是当我注册了一个1.8M大小的js-service文件，我发现页面加载失败了。查看sdk源码发现register service内部执行js的过程是放在子线程进行的，所以我render page很可能会晚于register service。
所以，register service方法需要支持回调，这样我们在回调中再去render page就不会出现页面加载出来但是register service还没执行完的情况了。