### PR TITLE
[WEEX-669][android] fix slider crash when adapter is null

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/action/GraphicActionLayout.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/action/GraphicActionLayout.java
@@ -41,7 +41,7 @@ public class GraphicActionLayout extends BasicGraphicAction {
     }
 
     component.setDemission(mLayoutSize, mLayoutPosition);
-    component.setLayout(component);
+    component.setSafeLayout(component);
     component.setPadding(component.getPadding(), component.getBorder());
   }
 }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
@@ -682,7 +682,7 @@ public abstract class WXComponent<T extends View> extends WXBasicComponent imple
         component = this;
       }
       bindComponent(component);
-      setLayout(component);
+      setSafeLayout(component);
       setPadding(component.getPadding(), component.getBorder());
       applyEvents();
     }
@@ -701,7 +701,7 @@ public abstract class WXComponent<T extends View> extends WXBasicComponent imple
 
   public void applyLayoutOnly(){
     if(!isLazy()) {
-      setLayout(this);
+      setSafeLayout(this);
       setPadding(this.getPadding(), this.getBorder());
     }
   }
@@ -922,13 +922,19 @@ public abstract class WXComponent<T extends View> extends WXBasicComponent imple
   /**
    * layout view
    */
-  public void setLayout(WXComponent component) {
+  public void setSafeLayout(WXComponent component) {
     if (TextUtils.isEmpty(component.getComponentType())
             || TextUtils.isEmpty(component.getRef()) || component.getLayoutPosition() == null
             || component.getLayoutSize() == null) {
       return;
     }
+    setLayout(component);
+  }
 
+  /**
+   * layout view
+   */
+  public void setLayout(WXComponent component) {
     setLayoutSize(component.getLayoutSize());
     setLayoutPosition(component.getLayoutPosition());
     setPaddings(component.getPadding());

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSlider.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXSlider.java
@@ -214,7 +214,9 @@ public class WXSlider extends WXVContainer<FrameLayout> {
 
   @Override
   public void setLayout(WXComponent component) {
-    mAdapter.setLayoutDirectionRTL(this.isNativeLayoutRTL());
+    if (mAdapter != null) {
+      mAdapter.setLayoutDirectionRTL(this.isNativeLayoutRTL());
+    }
     super.setLayout(component);
   }
 

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/list/BasicListComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/list/BasicListComponent.java
@@ -198,11 +198,6 @@ public abstract class BasicListComponent<T extends ViewGroup & ListComponentView
 
   @Override
   public void setLayout(WXComponent component) {
-    if (TextUtils.isEmpty(component.getComponentType())
-            || TextUtils.isEmpty(component.getRef()) || component.getLayoutPosition() == null
-            || component.getLayoutSize() == null) {
-      return;
-    }
     if (component.getHostView() != null) {
       int layoutDirection = component.isNativeLayoutRTL() ? View.LAYOUT_DIRECTION_RTL : View.LAYOUT_DIRECTION_LTR;
       ViewCompat.setLayoutDirection(component.getHostView(), layoutDirection);

--- a/android/sdk/src/test/java/com/taobao/weex/ui/component/ComponentTest.java
+++ b/android/sdk/src/test/java/com/taobao/weex/ui/component/ComponentTest.java
@@ -49,7 +49,7 @@ public class ComponentTest {
       parent.createChildViewAt(-1);
     }
 
-    comp.setLayout(comp);
+    comp.setSafeLayout(comp);
 
 //    domObject = new TestDomObject();
 //    comp.updateDom(domObject);


### PR DESCRIPTION
fix slider crash when adapter is null

java.lang.NullPointerException: Attempt to invoke virtual method 'void com.taobao.weex.ui.view.WXCirclePageAdapter.setLayoutDirectionRTL(boolean)' on a null object reference
at com.taobao.weex.ui.component.WXSlider.setLayout(WXSlider.java:217)
at com.taobao.weex.ui.action.GraphicActionLayout.executeAction(GraphicActionLayout.java:44)
at com.taobao.weex.ui.action.BasicGraphicAction.run(BasicGraphicAction.java:68)
at android.os.Handler.handleCallback(Handler.java:751)
at android.os.Handler.dispatchMessage(Handler.java:95)
at android.os.Looper.loop(Looper.java:154)
at android.app.ActivityThread.main(ActivityThread.java:6195)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:889)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)
