### PR TITLE
[jsfm] Still throw caught errors in event handler and callback

### DIFF
--- a/runtime/bridge/CallbackManager.js
+++ b/runtime/bridge/CallbackManager.js
@@ -67,6 +67,7 @@ export default class CallbackManager {
     }
     catch (e) {
       console.error(`[JS Framework] Failed to execute the hook function on "${key}".`)
+      throw e
     }
     return result
   }
@@ -81,6 +82,7 @@ export default class CallbackManager {
       }
       catch (error) {
         console.error(`[JS Framework] Failed to execute the callback function:\n ${error.toString()}`)
+        throw error
       }
     }
     return new Error(`invalid callback id "${callbackId}"`)

--- a/runtime/vdom/Element.js
+++ b/runtime/vdom/Element.js
@@ -493,6 +493,7 @@ export default class Element extends Node {
       catch (error) {
         console.error(`[JS Framework] Failed to invoke the event handler of "${type}" `
           + `on ${this.type} (${this.ref}):\n ${error.toString()}`)
+        throw error
       }
     }
 


### PR DESCRIPTION
Fix #1798

Javascript exceptions should be handled by native engines, catch them in the js framework will omit some errors and make developers hard to find reasons.