### PR TITLE
[WEEX][Android] When View Not InstanceOf WXGestureObservable, mGestureType is Null, remove event has none affect,

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXComponent.java
@@ -1501,16 +1501,19 @@ public abstract class WXComponent<T extends View> extends WXBasicComponent imple
     if (TextUtils.isEmpty(type)) {
       return;
     }
-    if (getEvents() == null || mAppendEvents == null || mGestureType == null) {
-      return;
-    }
 
     if (type.equals(Constants.Event.LAYEROVERFLOW))
       removeLayerOverFlowListener(getRef());
 
-    getEvents().remove(type);
-    mAppendEvents.remove(type);//only clean append events, not dom's events.
-    mGestureType.remove(type);
+    if(getEvents() != null){
+      getEvents().remove(type);
+    }
+    if(mAppendEvents != null) {
+      mAppendEvents.remove(type);//only clean append events, not dom's events.
+    }
+    if(mGestureType != null){
+      mGestureType.remove(type);
+    }
     removeEventFromView(type);
   }
 


### PR DESCRIPTION
[WEEX][Android] When View Not InstanceOf WXGestureObservable, mGestureType is Null, remove event has none affect,

demo:

http://rax.alibaba-inc.com/playground/e5d4fe01-48d6-4e18-a4d2-f96b63065546

