### PR TITLE
Android data base fix

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/appfram/storage/DefaultWXStorage.java
+++ b/android/sdk/src/main/java/com/taobao/weex/appfram/storage/DefaultWXStorage.java
@@ -143,15 +143,20 @@ public class DefaultWXStorage implements IWXStorageAdapter {
 
     @Override
     public void close() {
-        try {
-            mDatabaseSupplier.closeDatabase();
-            if (mExecutorService != null) {
-                mExecutorService.shutdown();
-                mExecutorService = null;
+        execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    mDatabaseSupplier.closeDatabase();
+                    if (mExecutorService != null) {
+                        mExecutorService.shutdown();
+                        mExecutorService = null;
+                    }
+                } catch (Exception e) {
+                    WXLogUtils.e(WXSQLiteOpenHelper.TAG_STORAGE, e.getMessage());
+                }
             }
-        } catch (Exception e) {
-            WXLogUtils.e(WXSQLiteOpenHelper.TAG_STORAGE, e.getMessage());
-        }
+        });
     }
 
     private boolean performSetItem(String key, String value, boolean isPersistent, boolean allowRetryWhenFull) {


### PR DESCRIPTION
fix a crash for storageModule:
crash stack
java stack
java.lang.IllegalStateException: Cannot perform this operation because the connection pool has been closed.
at android.database.sqlite.SQLiteConnectionPool.throwIfClosedLocked(SQLiteConnectionPool.java:962)
at android.database.sqlite.SQLiteConnectionPool.waitForConnection(SQLiteConnectionPool.java:599)
at android.database.sqlite.SQLiteConnectionPool.acquireConnection(SQLiteConnectionPool.java:348)
at android.database.sqlite.SQLiteSession.acquireConnection(SQLiteSession.java:894)
at android.database.sqlite.SQLiteSession.executeForLong(SQLiteSession.java:650)
at android.database.sqlite.SQLiteStatement.simpleQueryForLong(SQLiteStatement.java:125)
at android.database.DatabaseUtils.longForQuery(DatabaseUtils.java:886)
at android.database.DatabaseUtils.longForQuery(DatabaseUtils.java:874)
at android.database.sqlite.SQLiteDatabase.getPageSize(SQLiteDatabase.java:941)
at android.database.sqlite.SQLiteDatabase.setMaximumSize(SQLiteDatabase.java:924)
at com.taobao.weex.appfram.storage.WXSQLiteOpenHelper.ensureDatabase(WXSQLiteOpenHelper.java:179)
at com.taobao.weex.appfram.storage.WXSQLiteOpenHelper.getDatabase(WXSQLiteOpenHelper.java:78)
at com.taobao.weex.appfram.storage.DefaultWXStorage.performGetItem(DefaultWXStorage.java:239)
at com.taobao.weex.appfram.storage.DefaultWXStorage.access$100(DefaultWXStorage.java:39)
at com.taobao.weex.appfram.storage.DefaultWXStorage$2.run(DefaultWXStorage.java:79)
at com.taobao.weex.common.WXThread$SafeRunnable.run(WXThread.java:48)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
at java.lang.Thread.run(Thread.java:818)

This exception is caused by asynchronous read and write db, so add try catch to db operation and move close operation to same thread