### PR TITLE
[Android] fix callGcanvas导致的野指针问题

### DIFF
--- a/weex_core/Source/android/bridge/script_bridge_in_multi_process.cpp
+++ b/weex_core/Source/android/bridge/script_bridge_in_multi_process.cpp
@@ -267,14 +267,15 @@ static std::unique_ptr<IPCResult> HandleCallGCanvasLinkNative(
 //    retVal = WeexCoreManager::Instance()->script_bridge()->core_side()->CallGCanvasLinkNative(pageId, type,
 //                                                                                     args);
 
-      std::unique_ptr<IPCResult> ret = createVoidResult();
-      if (retVal) {
+  std::unique_ptr<IPCResult> ret = createVoidResult();
+  if (retVal) {
     jstring jDataStr = env->NewStringUTF(retVal);
     ret = std::unique_ptr<IPCResult>(
-        new IPCStringResult(jstring2WeexString(env, jDataStr)));
+            new IPCStringResult(jstring2WeexString(env, jDataStr)));
     env->DeleteLocalRef(jDataStr);
+    delete retVal;
     retVal = NULL;
-      }
+  }
 //      env->DeleteLocalRef(jPageId);
 //      env->DeleteLocalRef(val);
       return ret;

--- a/weex_core/Source/android/jsengine/object/weex_global_object.cpp
+++ b/weex_core/Source/android/jsengine/object/weex_global_object.cpp
@@ -369,9 +369,12 @@ JSFUNCTION functionGCanvasLinkNative(ExecState *state) {
     JSValue arg_js = state->argument(2);
     String arg_str = arg_js.toWTFString(state);
 
-    auto result = globalObject->js_bridge()->core_side()->CallGCanvasLinkNative(id_str.utf8().data(),
+    const char * resultChar = globalObject->js_bridge()->core_side()->CallGCanvasLinkNative(id_str.utf8().data(),
                                                                                 type, arg_str.utf8().data());
-    return JSValue::encode(String2JSValue(state, result));
+    auto result = resultChar;
+    auto ret = JSValue::encode(String2JSValue(state, result));
+    delete resultChar;
+    return ret;
 }
 
 JSFUNCTION functionT3DLinkNative(ExecState *state) {


### PR DESCRIPTION
fix the issue #2008 

A native crash with the stack:
SIGSEGV(SEGV_MAPERR):
#00 pc 0001a0a8 /system/lib/libc.so (strlen+71) [armeabi-v7a::bd65f13f1451c6c1a34a12381914242d]
#1 pc 002e693d /system/lib/libart.so (_ZN3art6mirror6String21AllocFromModifiedUtf8EPNS_6ThreadEPKc+8) [armeabi-v7a::383e31579b74445b901dcaeb5b37276b]
#2 pc 002b18ff /system/lib/libart.so (_ZN3art3JNI12NewStringUTFEP7_JNIEnvPKc+386) [armeabi-v7a::383e31579b74445b901dcaeb5b37276b]
#3 pc 00068b53 /lib/arm/libweexcore.so [armeabi-v7a::aa03e3a40249fd5e6a4e92bffa1aeb1a]
#4 pc 00067d41 /lib/arm/libweexcore.so (ZNSt17_Function_handlerIFSt10unique_ptrI9IPCResultSt14default_deleteIS1_EEP12IPCArgumentsEPS7_E9_M_invokeERKSt9_Any_dataS6+8) [armeabi-v7a::aa03e3a40249fd5e6a4e92bffa1aeb1a]
#5 pc 0006dc21 /lib/arm/libweexcore.so [armeabi-v7a::aa03e3a40249fd5e6a4e92bffa1aeb1a]
#6 pc 0006d1df /lib/arm/libweexcore.so [armeabi-v7a::aa03e3a40249fd5e6a4e92bffa1aeb1a]
#7 pc 00065fff /lib/arm/libweexcore.so (_ZN8WeexCore9WeexProxy6execJSEP7_JNIEnvP8_jobjectP8_jstringS6_S6_P13_jobjectArray+438) [armeabi-v7a::aa03e3a40249fd5e6a4e92bffa1aeb1a]
#8 pc 000610a1 /lib/arm/libweexcore.so [armeabi-v7a::aa03e3a40249fd5e6a4e92bffa1aeb1a]
#9 pc 00005605 /oat/arm/base.odex (oatexec+22021) [armeabi::74a1ccfee55579129f21b2286efa74e9]

the crash address is not the only and not zero.

the restore stack ：
./aarch64-linux-android-addr2line -e /libweexcore.so -f 00068b53 00067d41 0006dc21 0006d1df 00065fff 000610a1

_ZN7_JNIEnv12NewStringUTFEPKc
/Android/sdk/ndk-bundle/sysroot/usr/include/jni.h:842
ZNSt17_Function_handlerIFSt10unique_ptrI9IPCResultSt14default_deleteIS1_EEP12IPCArgumentsEPS7_E9_M_invokeERKSt9_Any_dataS6
/Android/sdk/ndk-bundle/sources/cxx-stl/gnu-libstdc++/4.9/include/functional:2025 (discriminator 1)
ZNKSt8functionIFSt10unique_ptrI9IPCResultSt14default_deleteIS1_EEP12IPCArgumentsEEclES6
/Android/sdk/ndk-bundle/sources/cxx-stl/gnu-libstdc++/4.9/include/functional:2439 (discriminator 1)
_ZN12_GLOBAL__N_113IPCSenderImpl4sendEP9IPCBuffer
/weex_core/Source/IPC/IPCSender.cpp:80 (discriminator 1)
_ZN8WeexCore9WeexProxy6execJSEP7_JNIEnvP8_jobjectP8_jstringS6_S6_P13_jobjectArray
/weex_core/Source/android/jsengine/multiprocess/WeexProxy.cpp:432 (discriminator 1)

the weex core version: 0.19.0-release