### PR TITLE
* [Android] Fix potential NPE in TextContentBoxMeasurement

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/layout/measurefunc/TextContentBoxMeasurement.java
+++ b/android/sdk/src/main/java/com/taobao/weex/layout/measurefunc/TextContentBoxMeasurement.java
@@ -194,7 +194,9 @@ public class TextContentBoxMeasurement extends ContentBoxMeasurement {
       WXSDKManager.getInstance().getWXRenderManager().postOnUiThread(new Runnable() {
         @Override
         public void run() {
-          mComponent.updateExtra(atomicReference.get());
+          if(mComponent!=null) {
+            mComponent.updateExtra(atomicReference.get());
+          }
         }
       }, mComponent.getInstanceId());
     }


### PR DESCRIPTION
This may cause crash if TextContentBoxMeasurement is destroyed and mComponent may be null