### PR TITLE
add support android anti-aliasing image

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/utils/ImageDrawable.java
+++ b/android/sdk/src/main/java/com/taobao/weex/utils/ImageDrawable.java
@@ -133,6 +133,8 @@ public class ImageDrawable extends PaintDrawable {
       // fix api 21 PaintDrawable crash
       paint.setAntiAlias(false);
     }
+    // add support android anti-aliasing image
+    paint.setFlags(Paint.ANTI_ALIAS_FLAG|Paint.FILTER_BITMAP_FLAG);
     super.onDraw(shape, canvas, paint);
   }
 


### PR DESCRIPTION
Fixed image component anti-alias problem when rendering some non-standard cut image under Android (ios have no such problem)

  * [ *] Make android support anti-aliased image