### PR TITLE
make android support anti-aliased image

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/utils/ImageDrawable.java
+++ b/android/sdk/src/main/java/com/taobao/weex/utils/ImageDrawable.java
@@ -132,9 +132,10 @@ public class ImageDrawable extends PaintDrawable {
     if (Build.VERSION.SDK_INT == Build.VERSION_CODES.LOLLIPOP) {
       // fix api 21 PaintDrawable crash
       paint.setAntiAlias(false);
+    } else {
+      // make android support anti-aliased image
+      paint.setFlags(Paint.ANTI_ALIAS_FLAG|Paint.FILTER_BITMAP_FLAG);
     }
-    // add support android anti-aliasing image
-    paint.setFlags(Paint.ANTI_ALIAS_FLAG|Paint.FILTER_BITMAP_FLAG);
     super.onDraw(shape, canvas, paint);
   }
 

--- a/android/sdk/src/main/java/com/taobao/weex/utils/ImageDrawable.java
+++ b/android/sdk/src/main/java/com/taobao/weex/utils/ImageDrawable.java
@@ -49,6 +49,8 @@ public class ImageDrawable extends PaintDrawable {
               (bm = ((BitmapDrawable) original).getBitmap()) != null) {
         ImageDrawable imageDrawable;
         imageDrawable = new ImageDrawable();
+        // fix android 9 image antialiasing
+        imageDrawable.getPaint().setFilterBitmap(true);
         imageDrawable.bitmapWidth = bm.getWidth();
         imageDrawable.bitmapHeight = bm.getHeight();
         BitmapShader bitmapShader = new BitmapShader(bm, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP);
@@ -132,9 +134,6 @@ public class ImageDrawable extends PaintDrawable {
     if (Build.VERSION.SDK_INT == Build.VERSION_CODES.LOLLIPOP) {
       // fix api 21 PaintDrawable crash
       paint.setAntiAlias(false);
-    } else {
-      // make android support anti-aliased image
-      paint.setFlags(Paint.ANTI_ALIAS_FLAG|Paint.FILTER_BITMAP_FLAG);
     }
     super.onDraw(shape, canvas, paint);
   }

--- a/android/sdk/src/main/java/com/taobao/weex/utils/ImageDrawable.java
+++ b/android/sdk/src/main/java/com/taobao/weex/utils/ImageDrawable.java
@@ -133,6 +133,8 @@ public class ImageDrawable extends PaintDrawable {
       // fix api 21 PaintDrawable crash
       paint.setAntiAlias(false);
     }
+    // add support android anti-aliasing image
+    paint.setFlags(Paint.ANTI_ALIAS_FLAG|Paint.FILTER_BITMAP_FLAG);
     super.onDraw(shape, canvas, paint);
   }
 


### PR DESCRIPTION
Fixed image component anti-alias problem when rendering some non-standard cut image under Android (ios have no such problem)