### PR TITLE
Fix WXTextView#getText() throws NullPointerException

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/view/WXTextView.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/view/WXTextView.java
@@ -86,7 +86,7 @@ public class WXTextView extends View implements WXGestureObservable, IWXTextView
 
   @Override
   public CharSequence getText() {
-    return textLayout.getText();
+    return textLayout != null ? textLayout.getText() : null;
   }
 
   public Layout getTextLayout() {


### PR DESCRIPTION
Fix WXTextView#getText() throws NullPointerException before textLayout instanced.