### PR TITLE
[iOS] Fix bug that when imagesrc is nil, image loader is still called.

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXImageComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXImageComponent.m
@@ -406,6 +406,9 @@ WX_EXPORT_METHOD(@selector(save:))
             [[self imageLoader] setImageViewWithURL:(UIImageView*)self.view url:[NSURL URLWithString:newURL] placeholderImage:nil options:extInfo progress:nil completed:nil];
         }
         newURL = [[self imageSrc] copy];
+        if ([newURL length] == 0) {
+            return;
+        }
         WX_REWRITE_URL([self imageSrc], WXResourceTypeImage, self.weexInstance)
         NSDictionary *userInfo = @{@"imageQuality":@(self.imageQuality), @"imageSharp":@(self.imageSharp),  @"blurRadius":@(self.blurRadius), @"instanceId":[self _safeInstanceId], @"pageURL": self.weexInstance.scriptURL ?: @""};
         [[self imageLoader] setImageViewWithURL:(UIImageView*)self.view url:[NSURL URLWithString:newURL] placeholderImage:nil options:userInfo progress:^(NSInteger receivedSize, NSInteger expectedSize) {


### PR DESCRIPTION
First of all, thank you for your contribution! 

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

<!-- 
How to use github markdown?
### checkable example
- [x] checked
- [ ] not checked
More github Markdown info to see https://guides.github.com/features/mastering-markdown/
-->

CheckList:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.

**elif** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update test scripts for the feature.
  * [ ] Add unit tests for the feature.

<!--
（请在***提交***前删除这段描述）

Notes: Weex will move into Apache Software Foundation (ASF) on Feb 24 2017.

Our new GitHub repo is https://github.com/apache/incubator-weex

After Feb 24 2017, we only accept pull requests from https://github.com/apache/incubator-weex

Thank you for your support.

----

注意：Weex 将于 2017-02-24 迁移至 Apache 基金会

届时我们会使用新的 GitHub 仓库：https://github.com/apache/incubator-weex 并在那里继续接受大家的 pull request。

更多详情请关注：https://github.com/weexteam/article/issues/130

感谢理解和支持

-->

<!--
（请在***提交***前删除这段描述）
It's ***RECOMMENDED*** to submit typo fix, new demo, tiny bugfix and large feature to `master` branch.
    
See [Branch Strategy](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management) for more detail.

----

错别字修改、新 demo、较小的 bugfix、甚至较大的功能都可以直接提到 `master` 分支；

查看完整的[分支策略 (英文)](https://github.com/alibaba/weex/blob/dev/CONTRIBUTING.md#branch-management)。

-->
