### PR TITLE
[Android]  add params for scroller to control auto scroller to beginposition

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXScroller.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXScroller.java
@@ -494,7 +494,16 @@ public class WXScroller extends WXVContainer<ViewGroup> implements WXScrollViewL
                   int mw = frameLayout.getMeasuredWidth();
                   scrollView.scrollTo(mw, component.getScrollY());
                 } else {
-                  scrollView.scrollTo(0, component.getScrollY());
+                  boolean scrollToBegin = true;
+                  Object scrollToBeginOnLTR = getAttrs().get("scrollToBegin");
+                  if (scrollToBeginOnLTR instanceof String){
+                    if("false".equalsIgnoreCase((String)scrollToBeginOnLTR)){
+                      scrollToBegin = false;
+                    }
+                  }
+                  if (scrollToBegin){
+                    scrollView.scrollTo(0, component.getScrollY());
+                  }
                 }
               }
             });


### PR DESCRIPTION
- feture: if scrooler has attr `scrollToBegin=false`,then   scroller will not scroller to begin position auto when content layout change
- doc pr: https://github.com/apache/incubator-weex-site/pull/334
