### PR TITLE
[iOS][Android] fix scrollToElement performance incorrect  offset

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXScroller.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXScroller.java
@@ -798,19 +798,24 @@ public class WXScroller extends WXVContainer<ViewGroup> implements WXScrollViewL
     int viewXInScroller = 0;
     if (this.isLayoutRTL()) {
       // if layout direction is rtl, we need calculate rtl scroll x;
-      if (getInnerView().getChildCount() > 0) {
-        int totalWidth = getInnerView().getChildAt(0).getWidth();
-        int displayWidth = getInnerView().getMeasuredWidth();
-        viewXInScroller = totalWidth - (component.getAbsoluteX() - getAbsoluteX()) - displayWidth;
+      if (component.getParent() != null && component.getParent() == this) {
+        if (getInnerView().getChildCount() > 0) {
+          int totalWidth = getInnerView().getChildAt(0).getWidth();
+          int displayWidth = getInnerView().getMeasuredWidth();
+          viewXInScroller = totalWidth - (component.getAbsoluteX() - getAbsoluteX()) - displayWidth;
+        } else {
+          viewXInScroller = component.getAbsoluteX() - getAbsoluteX();
+        }
+        offsetFloat = -offsetFloat;
       } else {
-        viewXInScroller = component.getAbsoluteX() - getAbsoluteX();
+        int displayWidth = getInnerView().getMeasuredWidth();
+        viewXInScroller = component.getAbsoluteX() - getAbsoluteX() - displayWidth + (int)component.getLayoutWidth();
       }
-      offsetFloat = - offsetFloat;
     } else {
       viewXInScroller = component.getAbsoluteX() - getAbsoluteX();
     }
-
     scrollBy(viewXInScroller - getScrollX() + (int) offsetFloat, viewYInScroller - getScrollY() + (int) offsetFloat, smooth);
+
   }
 
   /**

--- a/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.mm
+++ b/ios/sdk/WeexSDK/Sources/Component/WXScrollerComponent.mm
@@ -567,7 +567,12 @@ WX_EXPORT_METHOD(@selector(resetLoadmore))
     CGFloat scaleFactor = self.weexInstance.pixelScaleFactor;
     
     if (_scrollDirection == WXScrollDirectionHorizontal) {
-        CGFloat contentOffetX = [component.supercomponent.view convertPoint:component.view.frame.origin toView:self.view].x;
+        CGFloat contentOffetX = 0;
+        if (self.isDirectionRTL && component.supercomponent != self) {
+            contentOffetX = [component.supercomponent.view convertPoint:CGPointMake(CGRectGetMaxX(component.view.frame), component.view.frame.origin.y) toView:self.view].x;
+        } else {
+            contentOffetX = [component.supercomponent.view convertPoint:component.view.frame.origin toView:self.view].x;
+        }
         contentOffetX += offset * scaleFactor;
         
         if (scrollView.contentSize.width >= scrollView.frame.size.width && contentOffetX > scrollView.contentSize.width - scrollView.frame.size.width) {


### PR DESCRIPTION
Since i start use Rax UI Framework - Nuke, i found i can't scroll to correct element on RTL layout.
Because Nuke will add a  container div between scroller and scroller's child element. 

ScrollToElement only can scroll to the direct child element on RTL direction in the online version，
now i fix the problem，scrollToElement can scroll to indirect child element.

BTW. i found scroll to begin let front-end engineer confused, now i found a better way to key offset when layout direction changed.


Nuke DEMO： https://jsplayground.taobao.org/raxplayground/5bf4b469-8eb1-4f5d-91df-912cd085ab7b
Direction chang DEMO：http://dotwe.org/vue/09cb6e35412f96c25c423fd50a929597

![scrollToElement](https://user-images.githubusercontent.com/5855934/54113987-607fa400-4424-11e9-98e8-caf15ae4b041.png)
