### PR TITLE
[jsfm] add type check for register modules and components

### DIFF
--- a/runtime/api/component.js
+++ b/runtime/api/component.js
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { isPlainObject } from '../shared/utils'
 import { registerElement } from '../vdom/WeexElement'
 
 const weexComponents = {}
@@ -34,7 +35,7 @@ export function registerComponents (newComponents) {
       if (typeof component === 'string') {
         weexComponents[component] = true
       }
-      else if (typeof component === 'object' && typeof component.type === 'string') {
+      else if (isPlainObject(component) && typeof component.type === 'string') {
         weexComponents[component.type] = component
         registerElement(component.type, component.methods)
       }

--- a/runtime/api/module.js
+++ b/runtime/api/module.js
@@ -17,25 +17,29 @@
  * under the License.
  */
 
+import { hasOwn, isPlainObject } from '../shared/utils'
+
 const weexModules = {}
 
 /**
  * Register native modules information.
  * @param {object} newModules
  */
-export function registerModules (newModules) {
+export function registerModules (newModules = {}) {
   for (const name in newModules) {
-    if (!weexModules[name]) {
+    if (!hasOwn(weexModules, name)) {
       weexModules[name] = {}
     }
-    newModules[name].forEach(method => {
-      if (typeof method === 'string') {
-        weexModules[name][method] = true
-      }
-      else {
-        weexModules[name][method.name] = method.args
-      }
-    })
+    if (Array.isArray(newModules[name])) {
+      newModules[name].forEach(method => {
+        if (typeof method === 'string') {
+          weexModules[name][method] = true
+        }
+        else if (isPlainObject(method) && typeof method.name === 'string') {
+          weexModules[name][method.name] = method.args || []
+        }
+      })
+    }
   }
 }
 

--- a/runtime/frameworks/legacy/app/register.js
+++ b/runtime/frameworks/legacy/app/register.js
@@ -50,17 +50,19 @@ export function initModules (modules, ifReplace) {
     }
 
     // push each non-existed new method
-    modules[moduleName].forEach(function (method) {
-      if (typeof method === 'string') {
-        method = {
-          name: method
+    if (Array.isArray(modules[moduleName])) {
+      modules[moduleName].forEach(function (method) {
+        if (typeof method === 'string') {
+          method = {
+            name: method
+          }
         }
-      }
 
-      if (!methods[method.name] || ifReplace) {
-        methods[method.name] = method
-      }
-    })
+        if (!methods[method.name] || ifReplace) {
+          methods[method.name] = method
+        }
+      })
+    }
   }
 }
 

--- a/runtime/shared/utils.js
+++ b/runtime/shared/utils.js
@@ -30,6 +30,14 @@ export function typof (v) {
   return s.substring(8, s.length - 1)
 }
 
+export function isPlainObject (value) {
+  return Object.prototype.toString.call(value) === '[object Object]'
+}
+
+export function hasOwn (object, key) {
+  return isPlainObject(object) && Object.prototype.hasOwnProperty.call(object, key)
+}
+
 export function bufferToBase64 (buffer) {
   if (typeof btoa !== 'function') {
     return ''

--- a/runtime/vdom/WeexElement.js
+++ b/runtime/vdom/WeexElement.js
@@ -37,7 +37,7 @@ const registeredElements = {}
  */
 export function registerElement (type, methods) {
   // Skip when no special component methods.
-  if (!methods || !methods.length) {
+  if (!Array.isArray(methods) || !methods.length) {
     return
   }
 


### PR DESCRIPTION
<!-- First of all, thank you for your contribution! 

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/apache/incubator-weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://weex.io/guide/contribute/how-to-contribute.html#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [document](https://weex.io/guide/contribute/how-to-contribute.html#contribute-code-or-document) -->


# Brief Description of the PR

Add safe type check for the `registerModules` and `registerComponents` API, make sure it won't throw js error even if the parameter has an invalid type.