### PR TITLE
[iOS] Fix <image> can't display picture with url which contains Chinese words. (#2135)

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
+++ b/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
@@ -766,8 +766,12 @@ typedef enum : NSUInteger {
     if (!url) {
         return nil;
     }
-    
-    return [NSURL URLWithString:url relativeToURL:_scriptURL];
+    NSURL *result = [NSURL URLWithString:url relativeToURL:_scriptURL];
+    if (result) {
+        return result;
+    }
+    // if result is nil, try url-encode the 'url' string.
+    return [NSURL URLWithString:[url stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding] relativeToURL:_scriptURL];
 }
 
 - (BOOL)checkModuleEventRegistered:(NSString*)event moduleClassName:(NSString*)moduleClassName


### PR DESCRIPTION
<!-- First of all, thank you for your contribution! 

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/apache/incubator-weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://weex.io/guide/contribute/how-to-contribute.html#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [document](https://weex.io/guide/contribute/how-to-contribute.html#contribute-code-or-document) -->

When convert a nonnull NSString to NSURL failed, should try url encode.

issue detail: #2135 