### PR TITLE
[iOS] Fix the border of view hasn't gone after changing border width to 0 dynamically; (#2153)

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXComponent_internal.h
+++ b/ios/sdk/WeexSDK/Sources/Component/WXComponent_internal.h
@@ -130,6 +130,8 @@ typedef id (^WXDataBindingBlock)(NSDictionary *data, BOOL *needUpdate);
     WXBorderStyle _borderBottomStyle;
     WXBorderStyle _borderLeftStyle;
     
+    NSInteger _lastBorderRecords; // Records last border drawing
+    
     BOOL _isViewTreeIgnored; // Component is added to super, but it is not added to views.
     BOOL _isFixed;
     BOOL _async;

--- a/ios/sdk/WeexSDK/Sources/Display/WXComponent+Display.m
+++ b/ios/sdk/WeexSDK/Sources/Display/WXComponent+Display.m
@@ -31,6 +31,15 @@
 
 #pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
 
+typedef NS_ENUM(NSInteger, WXComponentBorderRecord) {
+    WXComponentBorderRecordNone = 0,
+    WXComponentBorderRecordTop = 1,
+    WXComponentBorderRecordRight = 1 << 1,
+    WXComponentBorderRecordBottom = 1 << 2,
+    WXComponentBorderRecordLeft = 1 << 3,
+    WXComponentBorderRecordAll = WXComponentBorderRecordTop | WXComponentBorderRecordRight | WXComponentBorderRecordBottom | WXComponentBorderRecordLeft
+};
+
 @implementation WXComponent (Display)
 
 #pragma mark Public
@@ -61,7 +70,7 @@
         return YES;
     }
     
-    if (![self _needsDrawBorder]) {
+    if (![self _needsDrawBorder] && _lastBorderRecords == WXComponentBorderRecordNone) {
         WXLogDebug(@"No need to draw border for %@", self.ref);
         WXPerformBlockOnMainThread(^{
             [self _resetNativeBorderRadius];
@@ -354,6 +363,9 @@
         CGContextAddLineToPoint(context, topLeft, _borderTopWidth/2);
         CGContextAddArc(context, topLeft, topLeft, topLeft-_borderTopWidth/2, -M_PI_2, -M_PI_2-M_PI_4-(_borderLeftWidth>0?0:M_PI_4), 1);
         CGContextStrokePath(context);
+        _lastBorderRecords |= WXComponentBorderRecordTop;
+    } else {
+        _lastBorderRecords &= ~(WXComponentBorderRecordTop);
     }
     
     // Left
@@ -372,6 +384,9 @@
         CGContextAddLineToPoint(context, _borderLeftWidth/2, size.height-bottomLeft);
         CGContextAddArc(context, bottomLeft, size.height-bottomLeft, bottomLeft-_borderLeftWidth/2, M_PI, M_PI-M_PI_4-(_borderBottomWidth>0?0:M_PI_4), 1);
         CGContextStrokePath(context);
+        _lastBorderRecords |= WXComponentBorderRecordLeft;
+    } else {
+        _lastBorderRecords &= ~WXComponentBorderRecordLeft;
     }
     
     // Bottom
@@ -390,6 +405,9 @@
         CGContextAddLineToPoint(context, size.width-bottomRight, size.height-_borderBottomWidth/2);
         CGContextAddArc(context, size.width-bottomRight, size.height-bottomRight, bottomRight-_borderBottomWidth/2, M_PI_2, M_PI_4-(_borderRightWidth > 0?0:M_PI_4), 1);
         CGContextStrokePath(context);
+        _lastBorderRecords |= WXComponentBorderRecordBottom;
+    } else {
+        _lastBorderRecords &= ~WXComponentBorderRecordBottom;
     }
     
     // Right
@@ -408,9 +426,15 @@
         CGContextAddLineToPoint(context, size.width-_borderRightWidth/2, topRight);
         CGContextAddArc(context, size.width-topRight, topRight, topRight-_borderRightWidth/2, 0, -M_PI_4-(_borderTopWidth > 0?0:M_PI_4), 1);
         CGContextStrokePath(context);
+        _lastBorderRecords |= WXComponentBorderRecordRight;
+    } else {
+        _lastBorderRecords &= ~WXComponentBorderRecordRight;
     }
-    
-    CGContextStrokePath(context);
+    if (_lastBorderRecords <= 0 || _lastBorderRecords > WXComponentBorderRecordAll) {
+        CGContextClearRect(context, rect);
+    } else {
+        CGContextStrokePath(context);
+    }
     
     //clipRadius is beta feature
     //TO DO: remove _clipRadius property


### PR DESCRIPTION
<!-- First of all, thank you for your contribution! 

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/apache/incubator-weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://weex.io/guide/contribute/how-to-contribute.html#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [document](https://weex.io/guide/contribute/how-to-contribute.html#contribute-code-or-document) -->

The point is `_needsDrawBorder` in [WXComponent needsDrawRect]. 

When the border width changes to 0 from a non-zero value, it calls `... --> display --> _willDisplayLayer: --> needsDrawRect --> ...`. Then the border drawing is according to the result of  `needsDrawRect`. 

```
- (void)_willDisplayLayer:(CALayer *)layer
{
    ...
    BOOL needsDrawRect = [self needsDrawRect];
    WXDisplayBlock displayBlock;
    if (_useCompositing) {
        displayBlock = [self _compositeDisplayBlock];
    } else {
        displayBlock = [self _displayBlock];
    }
    WXDisplayCompletionBlock completionBlock = [self _displayCompletionBlock];
    
    if (!displayBlock || !needsDrawRect) {
        if (completionBlock) {
            completionBlock(layer, NO);
        }
        return;
    }
    ...
}
```
And the result of `needsDrawRect` is related on the result of `_needsDrawBorder`.

```objc
- (BOOL)needsDrawRect
{
    if (_useCompositing || _isCompositingChild) {
        return YES;
    }
    
    if (![self _needsDrawBorder] ) {
        ...
        return NO;
    }
    
    return YES;
}

```

But the result of `_needsDrawBorder` is only calculated by comparing the current border variables(`_border...Style`, `_border...Color`, `_border...Width`) with the pre-defaults. So that when the border width changes to zero from a non-zero value, `_needsDrawBorder` returns `NO` because current vars are equal to the pre-defaults. Then that cause `_drawBorderWithContext` not be called. Border is still there.

I considered that `_needsDrawBorder` has it's practical use, so I did not change it's implementation, just add a variable for recording the last borders instead. 

Issue detail: #2153 