### PR TITLE
[Android] Fire event when span within an a-label is clicked.

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/richtext/node/ANode.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/richtext/node/ANode.java
@@ -21,7 +21,9 @@ package com.taobao.weex.ui.component.richtext.node;
 import android.content.Context;
 import android.text.SpannableStringBuilder;
 
+import com.taobao.weex.ui.component.richtext.WXRichText;
 import com.taobao.weex.ui.component.richtext.span.ASpan;
+import com.taobao.weex.utils.WXUtils;
 
 class ANode extends RichTextNode {
 
@@ -54,7 +56,7 @@ class ANode extends RichTextNode {
   protected void updateSpans(SpannableStringBuilder spannableStringBuilder, int level) {
     super.updateSpans(spannableStringBuilder, level);
     if (attr != null && attr.containsKey(HREF)) {
-      ASpan aSpan = new ASpan(mInstanceId, attr.get(HREF).toString());
+      ASpan aSpan = new ASpan(mInstanceId, attr.get(HREF).toString(), mComponentRef,WXUtils.getString(attr.get(RichTextNode.PSEUDO_REF),""));
       spannableStringBuilder.setSpan(aSpan, 0, spannableStringBuilder.length(),
           createSpanFlag(level));
     }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/richtext/node/RichTextNode.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/richtext/node/RichTextNode.java
@@ -55,6 +55,7 @@ public abstract class RichTextNode {
     public static final String VALUE = Constants.Name.VALUE;
     public static final String ITEM_CLICK="itemclick";
     public static final String PSEUDO_REF="pseudoRef";
+    public static final String CLICK_HREF="click://";
     private static final int MAX_LEVEL = Spanned.SPAN_PRIORITY >> Spanned.SPAN_PRIORITY_SHIFT;
 
     protected final Context mContext;

--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/richtext/span/ASpan.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/richtext/span/ASpan.java
@@ -21,20 +21,46 @@ package com.taobao.weex.ui.component.richtext.span;
 import android.text.TextPaint;
 import android.text.style.ClickableSpan;
 import android.view.View;
+
+import com.taobao.weex.WXSDKInstance;
+import com.taobao.weex.WXSDKManager;
+import com.taobao.weex.ui.component.richtext.node.RichTextNode;
 import com.taobao.weex.utils.ATagUtil;
+import com.taobao.weex.utils.WXDataStructureUtil;
+
+import java.util.Map;
 
 public class ASpan extends ClickableSpan {
 
   private String mInstanceId, mURL;
+  private final String mComponentRef;
+  private final String mPseudoRef;
 
-  public ASpan(String instanceId, String url) {
+  public ASpan(String instanceId, String url,String componentRef, String pseudoRef) {
     mInstanceId = instanceId;
     mURL = url;
+    mComponentRef = componentRef;
+    mPseudoRef = pseudoRef;
+  }
+  public ASpan(String instanceId, String url) {
+    this.mInstanceId = instanceId;
+    this.mURL = url;
+    this.mComponentRef = "";
+    this.mPseudoRef = "";
   }
 
   @Override
   public void onClick(View widget) {
-    ATagUtil.onClick(widget, mInstanceId, mURL);
+    if (mURL.equals(RichTextNode.CLICK_HREF) && !(mPseudoRef.isEmpty()) &&!(mComponentRef.isEmpty())) {
+      WXSDKInstance instance = WXSDKManager.getInstance().getSDKInstance(mInstanceId);
+      if (instance != null && !instance.isDestroy()) {
+        Map<String, Object> param = WXDataStructureUtil.newHashMapWithExpectedSize(1);
+        param.put(RichTextNode.PSEUDO_REF, mPseudoRef);
+        instance.fireEvent(mComponentRef, RichTextNode.ITEM_CLICK, param);
+      }
+    } else {
+      ATagUtil.onClick(widget, mInstanceId, mURL);
+    }
   }
 
   /**


### PR DESCRIPTION
* feature: If a span is clicked which is in an a-label of a richtext component, an itemclick event will be fired.
* demo: http://editor.weex.io/p/sunshl/Contribute/commit/b21e1133830b48767c6d00d712e415b2
* doc pr: https://github.com/apache/incubator-weex-site/pull/362
