### PR TITLE
[iOS] Fix custom component receive touch events.

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXComponent_internal.h
+++ b/ios/sdk/WeexSDK/Sources/Component/WXComponent_internal.h
@@ -90,6 +90,8 @@ typedef id (^WXDataBindingBlock)(NSDictionary *data, BOOL *needUpdate);
     UILongPressGestureRecognizer *_longPressGesture;
     UIPanGestureRecognizer *_panGesture;
     
+    BOOL _cancelsTouchesInView;
+    
     BOOL _listenPanStart;
     BOOL _listenPanMove;
     BOOL _listenPanEnd;

--- a/ios/sdk/WeexSDK/Sources/Events/WXComponent+Events.m
+++ b/ios/sdk/WeexSDK/Sources/Events/WXComponent+Events.m
@@ -388,6 +388,7 @@ if ([removeEventName isEqualToString:@#eventName1]||[removeEventName isEqualToSt
     if (!_tapGesture) {
         _tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(onClick:)];
         _tapGesture.delegate = self;
+        _tapGesture.cancelsTouchesInView = _cancelsTouchesInView;
         [self.view addGestureRecognizer:_tapGesture];
     }
 }

--- a/ios/sdk/WeexSDK/Sources/Model/WXComponent.mm
+++ b/ios/sdk/WeexSDK/Sources/Model/WXComponent.mm
@@ -100,6 +100,7 @@ static BOOL bNeedRemoveEvents = YES;
         _ariaHidden = nil;
         _accessible = nil;
         _accessibilityHintContent = nil;
+        _cancelsTouchesInView = YES;
         
         _async = NO;
         
@@ -151,6 +152,11 @@ static BOOL bNeedRemoveEvents = YES;
         if (attributes[@"customEvent"]) {
             _customEvent = [WXConvert BOOL:attributes[@"customEvent"]];
         }
+        
+        if (attributes[@"cancelsTouchesInView"]) {
+            _cancelsTouchesInView = [WXConvert BOOL:attributes[@"cancelsTouchesInView"]];
+        }
+
         
 #ifdef DEBUG
         WXLogDebug(@"flexLayout -> init component: ref : %@ , styles: %@",ref,styles);


### PR DESCRIPTION
    [iOS] Fix custom component receive touch events when root componet has click event.

    * bugfix: If a root component has click event, the custom component inside can't receive touch events.