### PR TITLE
[iOS] Fire event when span within an a-label is clicked.

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXRichText.mm
+++ b/ios/sdk/WeexSDK/Sources/Component/WXRichText.mm
@@ -198,6 +198,9 @@ do {\
     }
     else if (superNode.href) {
         node.href = superNode.href;
+        if (!(node.pseudoRef.length) && superNode.pseudoRef.length) {
+            node.pseudoRef = superNode.pseudoRef;
+        }
     }
     
     if (attributes[@"src"]) {


### PR DESCRIPTION
* feature: If a span is clicked which is in an a-label of a richtext component, an itemclick event will be fired.
* demo: http://editor.weex.io/p/sunshl/Contribute/commit/b21e1133830b48767c6d00d712e415b2
* doc pr: apache/incubator-weex-site#362
