### PR TITLE
[jsfm] Throw the caught exception in componentHook

### DIFF
--- a/runtime/bridge/receiver.js
+++ b/runtime/bridge/receiver.js
@@ -23,7 +23,8 @@ function fireEvent (document, nodeId, type, event, domChanges, params) {
   const el = document.getRef(nodeId)
   if (el) {
     return document.fireEvent(el, type, event, domChanges, params)
-  } else if (event) {
+  }
+  else if (event) {
     event._nodeId = nodeId
     return document.fireEvent(document.getRef('_documentElement'), type, event, domChanges, params)
   }
@@ -44,6 +45,10 @@ function componentHook (document, componentId, type, hook, args) {
   }
   catch (e) {
     console.error(`[JS Framework] Failed to trigger the "${type}@${hook}" hook on ${componentId}.`)
+
+    // Still throw the exception anyway, it should be caught
+    // and processed by the native for consistent error collecting.
+    throw e
   }
   return result
 }


### PR DESCRIPTION
<!-- First of all, thank you for your contribution! 

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/apache/incubator-weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://weex.io/guide/contribute/how-to-contribute.html#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [document](https://weex.io/guide/contribute/how-to-contribute.html#contribute-code-or-document) -->

# Brief Description of the PR

Still throw the caught exception in the "componentHook" anyway, it should be processed by the native for consistent error collecting.

<!-- # Additional content -->