### PR TITLE
* [Android] Fix android playground run unexpectedly on arm-v7a platform

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,8 +50,6 @@ subprojects {
         targetSdkVersion=26
         supportLibVersion="26.0.2"
         fastjsonLibVersion="1.1.46.android"
-        //Default value for armABIOnly is true
-        armABIOnly = !project.hasProperty("armABIOnly") || armABIOnly.equals('true')
         //Default value for buildCpp is true
         buildCpp = !project.hasProperty("buildCpp") || buildCpp.equals("true")
         //Default value for disableCov is false

--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -137,11 +137,7 @@ android {
         versionCode 1
         versionName project.version
         ndk {
-            if (project.armABIOnly){
-                abiFilters "armeabi"
-            } else {
-                abiFilters "armeabi-v7a", "armeabi", "x86"
-            }
+            abiFilters "armeabi-v7a", "armeabi", "x86"
         }
         externalNativeBuild {
             cmake {


### PR DESCRIPTION
Remove armABIOnly flag, which will cause 32 bits so and 64 bits cross link problem.