### PR TITLE
[core] fix flex-end in row-reverse

### DIFF
--- a/weex_core/Source/core/layout/layout.cpp
+++ b/weex_core/Source/core/layout/layout.cpp
@@ -715,7 +715,9 @@ namespace WeexCore {
 
     for (WXCoreFlexLine *flexLine: lines) {
       float spaceBetweenItem = 0.f;
-      layoutFlexlineHorizontal(width, flexLine, childLeft, childRight, spaceBetweenItem);
+      // Bugfix: when flex-direction is row-reverse, justify-content:flex-end is not available, it always performance as flex-start
+      // layoutFlexlineHorizontal(width, flexLine, childLeft, childRight, spaceBetweenItem);
+      layoutFlexlineHorizontal(isRtl, width, flexLine, childLeft, childRight, spaceBetweenItem);
       spaceBetweenItem = std::max(spaceBetweenItem, 0.f);
 
       if(absoulteItem == nullptr) {
@@ -740,46 +742,65 @@ namespace WeexCore {
     }
   }
 
+  void WXCoreLayoutNode::layoutFlexlineHorizontal(const bool isRTL,
+                                                  const float width,
+                                                  const WXCoreFlexLine *const flexLine,
+                                                  float &childLeft,
+                                                  float &childRight,
+                                                  float &spaceBetweenItem) const {
+      Index visibleCount, visibleItem;
+      float denominator;
+      switch (mCssStyle->mJustifyContent) {
+          case kJustifyCenter:
+              childLeft = (width - flexLine->mMainSize - mCssStyle->sumPaddingBorderOfEdge(kRight)
+                              + mCssStyle->sumPaddingBorderOfEdge(kLeft)) / 2;
+              childRight = childLeft + flexLine->mMainSize;
+              break;
+          case kJustifySpaceAround:
+              visibleCount = flexLine->mItemCount;
+              if (visibleCount != 0) {
+                  spaceBetweenItem =
+                  (width - flexLine->mMainSize - sumPaddingBorderAlongAxis(this, true)) / visibleCount;
+              }
+              childLeft = getPaddingLeft() + getBorderWidthLeft() + spaceBetweenItem / 2.f;
+              childRight = width - getPaddingRight() - getBorderWidthRight() - spaceBetweenItem / 2.f;
+              break;
+          case kJustifySpaceBetween:
+              childLeft = getPaddingLeft() + getBorderWidthLeft();
+              visibleItem = flexLine->mItemCount;
+              denominator = visibleItem != 1 ? visibleItem - 1 : 1.f;
+              spaceBetweenItem =
+              (width - flexLine->mMainSize - sumPaddingBorderAlongAxis(this, true)) / denominator;
+              childRight = width - getPaddingRight() - getBorderWidthRight();
+              break;
+          case kJustifyFlexEnd:
+              if (isRTL) {
+                  childLeft = getPaddingLeft() + getBorderWidthLeft();
+                  childRight = flexLine->mMainSize + getPaddingLeft() + getBorderWidthLeft();
+              } else {
+                  childLeft = width - flexLine->mMainSize - getPaddingRight() - getBorderWidthRight();
+                  childRight = width - getPaddingRight() - getBorderWidthRight();
+              }
+              break;
+          case kJustifyFlexStart:
+          default:
+              if (isRTL) {
+                  childLeft = width - flexLine->mMainSize - getPaddingRight() - getBorderWidthRight();
+                  childRight = width - getPaddingRight() - getBorderWidthRight();
+              } else {
+                  childLeft = getPaddingLeft() + getBorderWidthLeft();
+                  childRight = flexLine->mMainSize + getPaddingLeft() + getBorderWidthLeft();
+              }
+              break;
+      }
+  }
+    
   void WXCoreLayoutNode::layoutFlexlineHorizontal(const float width,
                               const WXCoreFlexLine *const flexLine,
                               float &childLeft,
                               float &childRight,
                               float &spaceBetweenItem) const {
-    Index visibleCount, visibleItem;
-    float denominator;
-    switch (mCssStyle->mJustifyContent) {
-      case kJustifyFlexEnd:
-        childLeft = width - flexLine->mMainSize - getPaddingRight() - getBorderWidthRight();
-        childRight = width - getPaddingLeft() - getBorderWidthLeft();
-        break;
-      case kJustifyCenter:
-        childLeft = (width - flexLine->mMainSize - mCssStyle->sumPaddingBorderOfEdge(kRight)
-            + mCssStyle->sumPaddingBorderOfEdge(kLeft)) / 2;
-        childRight = childLeft + flexLine->mMainSize;
-        break;
-      case kJustifySpaceAround:
-        visibleCount = flexLine->mItemCount;
-        if (visibleCount != 0) {
-          spaceBetweenItem =
-              (width - flexLine->mMainSize - sumPaddingBorderAlongAxis(this, true)) / visibleCount;
-        }
-        childLeft = getPaddingLeft() + getBorderWidthLeft() + spaceBetweenItem / 2.f;
-        childRight = width - getPaddingRight() - getBorderWidthRight() - spaceBetweenItem / 2.f;
-        break;
-      case kJustifySpaceBetween:
-        childLeft = getPaddingLeft() + getBorderWidthLeft();
-        visibleItem = flexLine->mItemCount;
-        denominator = visibleItem != 1 ? visibleItem - 1 : 1.f;
-        spaceBetweenItem =
-            (width - flexLine->mMainSize - sumPaddingBorderAlongAxis(this, true)) / denominator;
-        childRight = width - getPaddingRight() - getBorderWidthRight();
-        break;
-      case kJustifyFlexStart:
-      default:
-        childLeft = getPaddingLeft() + getBorderWidthLeft();
-        childRight = width - getPaddingRight() - getBorderWidthRight();
-        break;
-    }
+      layoutFlexlineHorizontal(false, width, flexLine, childLeft, childRight, spaceBetweenItem);
   }
 
   void WXCoreLayoutNode::layoutSingleChildHorizontal(const bool isRtl, const bool absoulteItem,

--- a/weex_core/Source/core/layout/layout.h
+++ b/weex_core/Source/core/layout/layout.h
@@ -613,6 +613,13 @@ namespace WeexCore {
     void layoutHorizontal(bool isRtl, float left, float top, float right, float bottom,
                           WXCoreLayoutNode*, WXCoreFlexLine *const flexLine);
 
+      void layoutFlexlineHorizontal(const bool isRTL,
+                                    const float width,
+                                    const WXCoreFlexLine *const flexLine,
+                                    float &childLeft,
+                                    float &childRight,
+                                    float &spaceBetweenItem) const;
+      
     void layoutFlexlineHorizontal(const float width,
                                          const WXCoreFlexLine *const flexLine,
                                          float &childLeft,


### PR DESCRIPTION
We fount that, when flex-direction is row-reverse, justify-content:flex-end is not available, not matter justify-content is flex-start or flex-end, layout system always layout items as flex-start.

Demo:
https://jsplayground.taobao.org/raxplayground/a3ad1d37-a6b7-41bb-9b72-3c00ab4ee161