### PR TITLE
[BUG] 修正动画处理时逐帧模拟的计算误差及逻辑问题，详见 #2347 。

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Module/WXTransition.mm
+++ b/ios/sdk/WeexSDK/Sources/Module/WXTransition.mm
@@ -317,10 +317,15 @@
     if (_propertyArray.count == 0) {
         return;
     }
-    double per = 1000 * (_transitionCount + 1 ) / (60 * _transitionDuration);//linear
+
+    // Bugfix: https://github.com/apache/incubator-weex/issues/2347
+    NSUInteger frameCount = _transitionDuration * 60 / 1000;
+    NSUInteger currentFrame = _transitionCount + 1;
+    double per = (double)currentFrame / frameCount; //linear
     if (![[NSString stringWithFormat:@"%@",_transitionTimingFunction] isEqualToString: kCAMediaTimingFunctionLinear]) {
-        per = [self solveWithx:((_transitionCount+2)*16)/_transitionDuration epsilon:SOLVE_EPS(_transitionDuration)];
+        per = [self solveWithx:per epsilon:SOLVE_EPS(_transitionDuration)];
     }
+
     NSString *transformString = [NSString string];
     for (WXTransitionInfo *info in _propertyArray) {
         if ([info.propertyName isEqualToString:@"backgroundColor"]) {


### PR DESCRIPTION
已反馈 Issue #2347 [[iOS] iOS上对视图进行位移等动画处理时，最后位移的结果相比预期值要多或少位移若干像素。](https://github.com/apache/incubator-weex/issues/2347) ，详细问题描述可跳转过去查看。