### PR TITLE
[Android] Add weex-rax-api.js for eagle

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
@@ -1576,14 +1576,12 @@ public class WXBridgeManager implements Callback, BactchExecutor {
         WXJSObject optionsObj = new WXJSObject(WXJSObject.JSON,
                 options == null ? "{}"
                         : WXJsonUtils.fromObjectToJSONString(options));
-        optionsObj = optionObjConvert(isSandBoxContext, type, instance.getRenderStrategy(), optionsObj);
+        optionsObj = optionObjConvert(isSandBoxContext, type, optionsObj);
         WXJSObject dataObj = new WXJSObject(WXJSObject.JSON,
                 data == null ? "{}" : data);
 
         WXJSObject apiObj;
-        if (type == BundType.Rax ||
-            instance.getRenderStrategy() == WXRenderStrategy.DATA_RENDER ||
-            instance.getRenderStrategy() == WXRenderStrategy.DATA_RENDER_BINARY) {
+        if (type == BundType.Rax || instance.getRenderStrategy() == WXRenderStrategy.DATA_RENDER) {
           if (mRaxApi == null) {
             IWXJsFileLoaderAdapter iwxJsFileLoaderAdapter = WXSDKEngine.getIWXJsFileLoaderAdapter();
             if(iwxJsFileLoaderAdapter != null) {
@@ -1661,8 +1659,8 @@ public class WXBridgeManager implements Callback, BactchExecutor {
     }
   }
 
-  public WXJSObject optionObjConvert(boolean useSandBox, BundType type, WXRenderStrategy renderStrategy, WXJSObject opt){
-    if (!useSandBox || (type == BundType.Others && renderStrategy != WXRenderStrategy.DATA_RENDER && renderStrategy != WXRenderStrategy.DATA_RENDER_BINARY )) {
+  public WXJSObject optionObjConvert(boolean useSandBox, BundType type, WXJSObject opt) {
+    if (!useSandBox || type == BundType.Others) {
       return opt;
     }
     try {
@@ -1691,18 +1689,7 @@ public class WXBridgeManager implements Callback, BactchExecutor {
       e.printStackTrace();
     }
     return opt;
-  }
 
-  /**
-   * Use {@link #optionObjConvert(boolean, BundType, WXRenderStrategy, WXJSObject)} instead
-   * @param useSandBox
-   * @param type
-   * @param opt
-   * @return
-   */
-  @Deprecated
-  public WXJSObject optionObjConvert(boolean useSandBox, BundType type, WXJSObject opt) {
-    return optionObjConvert(useSandBox, type, null, opt);
   }
 
   /**

--- a/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
@@ -1581,7 +1581,7 @@ public class WXBridgeManager implements Callback, BactchExecutor {
                 data == null ? "{}" : data);
 
         WXJSObject apiObj;
-        if (type == BundType.Rax) {
+        if (type == BundType.Rax || instance.getRenderStrategy() == WXRenderStrategy.DATA_RENDER) {
           if (mRaxApi == null) {
             IWXJsFileLoaderAdapter iwxJsFileLoaderAdapter = WXSDKEngine.getIWXJsFileLoaderAdapter();
             if(iwxJsFileLoaderAdapter != null) {

--- a/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
@@ -1576,12 +1576,14 @@ public class WXBridgeManager implements Callback, BactchExecutor {
         WXJSObject optionsObj = new WXJSObject(WXJSObject.JSON,
                 options == null ? "{}"
                         : WXJsonUtils.fromObjectToJSONString(options));
-        optionsObj = optionObjConvert(isSandBoxContext, type, optionsObj);
+        optionsObj = optionObjConvert(isSandBoxContext, type, instance.getRenderStrategy(), optionsObj);
         WXJSObject dataObj = new WXJSObject(WXJSObject.JSON,
                 data == null ? "{}" : data);
 
         WXJSObject apiObj;
-        if (type == BundType.Rax || instance.getRenderStrategy() == WXRenderStrategy.DATA_RENDER) {
+        if (type == BundType.Rax ||
+            instance.getRenderStrategy() == WXRenderStrategy.DATA_RENDER ||
+            instance.getRenderStrategy() == WXRenderStrategy.DATA_RENDER_BINARY) {
           if (mRaxApi == null) {
             IWXJsFileLoaderAdapter iwxJsFileLoaderAdapter = WXSDKEngine.getIWXJsFileLoaderAdapter();
             if(iwxJsFileLoaderAdapter != null) {
@@ -1659,8 +1661,8 @@ public class WXBridgeManager implements Callback, BactchExecutor {
     }
   }
 
-  public WXJSObject optionObjConvert(boolean useSandBox, BundType type, WXJSObject opt) {
-    if (!useSandBox || type == BundType.Others) {
+  public WXJSObject optionObjConvert(boolean useSandBox, BundType type, WXRenderStrategy renderStrategy, WXJSObject opt){
+    if (!useSandBox || (type == BundType.Others && renderStrategy != WXRenderStrategy.DATA_RENDER && renderStrategy != WXRenderStrategy.DATA_RENDER_BINARY )) {
       return opt;
     }
     try {
@@ -1689,7 +1691,18 @@ public class WXBridgeManager implements Callback, BactchExecutor {
       e.printStackTrace();
     }
     return opt;
+  }
 
+  /**
+   * Use {@link #optionObjConvert(boolean, BundType, WXRenderStrategy, WXJSObject)} instead
+   * @param useSandBox
+   * @param type
+   * @param opt
+   * @return
+   */
+  @Deprecated
+  public WXJSObject optionObjConvert(boolean useSandBox, BundType type, WXJSObject opt) {
+    return optionObjConvert(useSandBox, type, null, opt);
   }
 
   /**

--- a/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
@@ -34,7 +34,6 @@ import android.support.v4.util.ArrayMap;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
-
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
@@ -108,7 +107,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.Stack;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -1660,31 +1658,22 @@ public class WXBridgeManager implements Callback, BactchExecutor {
   }
 
   public WXJSObject optionObjConvert(boolean useSandBox, BundType type, WXJSObject opt) {
-    if (!useSandBox || type == BundType.Others) {
+    if (!useSandBox) {
       return opt;
     }
     try {
       String data = opt.data.toString();
       JSONObject obj = JSON.parseObject(data);
-      if (obj.getJSONObject("env") != null) {
-        JSONObject optEnv = obj.getJSONObject("env");
-        // obj.replace()
-        if (optEnv != null) {
-          JSONObject opts = optEnv.getJSONObject("options");
-          if (opts!= null) {
-            optEnv.remove("options");
-            Set<String> set = opts.keySet();
-            for(Iterator it = set.iterator(); it.hasNext();) {
-              String key = it.next().toString();
-              optEnv.put(key, opts.getString(key));
-            }
+      JSONObject optEnv;
+      if ((optEnv = obj.getJSONObject("env")) != null) {
+        JSONObject opts = optEnv.getJSONObject("options");
+        if (opts != null) {
+          for (String s : opts.keySet()) {
+            optEnv.put(s, opts.getString(s));
           }
         }
-        obj.remove("env");
-        obj.put("env", optEnv);
       }
-      WXJSObject optionsObj = new WXJSObject(WXJSObject.JSON, obj.toString());
-      return optionsObj;
+      return new WXJSObject(WXJSObject.JSON, obj.toString());
     } catch (Throwable e) {
       e.printStackTrace();
     }

--- a/weex_core/Source/core/bridge/platform/core_side_in_platform.cpp
+++ b/weex_core/Source/core/bridge/platform/core_side_in_platform.cpp
@@ -492,7 +492,7 @@ int CoreSideInPlatform::CreateInstance(const char *instanceId, const char *func,
               ->script_side()
               ->CreateInstance(instanceId.c_str(), func.c_str(), result,
                                opts_json.dump().c_str(), initData.c_str(),
-                               strcmp("Rax", bundleType) ? extendsApi.c_str() : "\0",
+                               strcmp("Rax", bundleType) ? "\0" : extendsApi.c_str(),
                                params);
         };
     if (strcmp(render_strategy, "DATA_RENDER") == 0) {

--- a/weex_core/Source/core/bridge/platform/core_side_in_platform.cpp
+++ b/weex_core/Source/core/bridge/platform/core_side_in_platform.cpp
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include "cstring"
 #include "core/bridge/platform/core_side_in_platform.h"
 #include "base/string_util.h"
 #include "base/log_defines.h"
@@ -491,7 +492,8 @@ int CoreSideInPlatform::CreateInstance(const char *instanceId, const char *func,
               ->script_side()
               ->CreateInstance(instanceId.c_str(), func.c_str(), result,
                                opts_json.dump().c_str(), initData.c_str(),
-                               extendsApi.c_str(),params);
+                               strcmp("Rax", bundleType) ? extendsApi.c_str() : "\0",
+                               params);
         };
     if (strcmp(render_strategy, "DATA_RENDER") == 0) {
         auto handler = EagleBridge::GetInstance()->data_render_handler();


### PR DESCRIPTION
1. Add weex-rax-api.js for all eagle page
2. If it is `eagle` and `Vue`, set the value of `weex-rax-api.js` to `\0`
3. Change the json structure of `weex.config.env`.

* Before
  * Normal Page

        {
            "bundleType": "Vue",
            "bundleUrl": "xxxx",
            "env": {
                "deviceHeight": "1200",
                "deviceWidth": "720",
                "enableBackupThread": "true",
                "enableBackupThreadCache": "true",
                .....
            },
            "render_strategy": "DATA_RENDER"
        }

  * Eagle Page
    As bundleType is `Others`, `env.options` will not be merged into `env`.

        {
            "bundleType": "Others",
            "bundleUrl": "xxxx",
            "env": {
                "deviceHeight": "1200",
                "deviceWidth": "720",
                "options": {
                    "enableBackupThread": "true",
                    "enableBackupThreadCache": "true",
                    .....
                }
                ....
            },
            "render_strategy": "DATA_RENDER"
        }

* After
  1. No matter what bundleType, always merge `env.options` into `env`
  1. For compatibility reason, remain the `env.options` at its original place.

            {
                "bundleType": "Other",
                "bundleUrl": "xxxx",
                "env": {
                    "deviceHeight": "1200",
                    "deviceWidth": "720",
                    "enableBackupThread": "true",
                    "enableBackupThreadCache": "true",
                    "options": {
                        "enableBackupThread": "true",
                        "enableBackupThreadCache": "true",
                        .....
                    }
                    .....
                },
                "render_strategy": "DATA_RENDER"
            }