### PR TITLE
[Android] Check weexVersion

### DIFF
--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -63,7 +63,24 @@ checkstyle {
     toolVersion = '6.9'
 }
 
-version = project.hasProperty('weexVersion')? project.getProperty('weexVersion') : "0.20.0.1"
+version = project.hasProperty('weexVersion') ?: "0.20.0.1"
+
+//Check version, the version must have 4 sections. The leading three section must be number, and the last section is odd number with or without suffix string.
+assert version.tokenize('.').eachWithIndex { it, i ->
+    if (i < 3) {
+        assert it.isNumber()
+    } else if (i == 3) {
+        it.split("-|_").toList().eachWithIndex { inner_it, inner_i ->
+            if(inner_i == 0){
+                assert inner_it.isNumber() && inner_it.toInteger() % 2
+            }else{
+                assert !inner_it.isNumber()
+            }
+        }.size == 4
+    } else {
+        assert false: "Please use semantic versioning witch 4 sections, you are using ${$ { i } + 1} section instead"
+    }
+}.size == 4
 
 android {
     compileSdkVersion project.compileSdkVersion

--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -63,24 +63,26 @@ checkstyle {
     toolVersion = '6.9'
 }
 
-version = project.hasProperty('weexVersion') ?: "0.20.0.1"
+version = project.hasProperty('weexVersion') ? project.getProperty('weexVersion') : "0.20.0.1"
 
 //Check version, the version must have 4 sections. The leading three section must be number, and the last section is odd number with or without suffix string.
-assert version.tokenize('.').eachWithIndex { it, i ->
-    if (i < 3) {
-        assert it.isNumber()
-    } else if (i == 3) {
-        it.split("-|_").toList().eachWithIndex { inner_it, inner_i ->
-            if(inner_i == 0){
-                assert inner_it.isNumber() && inner_it.toInteger() % 2
-            }else{
-                assert !inner_it.isNumber()
-            }
-        }.size == 4
-    } else {
-        assert false: "Please use semantic versioning witch 4 sections, you are using ${$ { i } + 1} section instead"
-    }
-}.size == 4
+if (!project.hasProperty('ignoreVersionCheck') || !project.getProperty('ignoreVersionCheck').equals("true")) {
+    assert version.tokenize('.').eachWithIndex { it, i ->
+        if (i < 3) {
+            assert it.isNumber()
+        } else if (i == 3) {
+            it.split("-|_").toList().eachWithIndex { inner_it, inner_i ->
+                if (inner_i == 0) {
+                    assert inner_it.isNumber() && inner_it.toInteger() % 2
+                } else {
+                    assert !inner_it.isNumber()
+                }
+            }.size == 4
+        } else {
+            assert false: "Please use semantic versioning witch 4 sections, you are using ${$ { i } + 1} section instead"
+        }
+    }.size == 4
+}
 
 android {
     compileSdkVersion project.compileSdkVersion


### PR DESCRIPTION
1. The version must have 4 sections like `0.20.0.1`
2. The leading three section must be number, and the last section is odd number with or without suffix string.
3. Version check can be ignored by `-PignoreVersionCheck=true`