### PR TITLE
[Android] Copy so.

### DIFF
--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -378,11 +378,11 @@ bintray {
 afterEvaluate {
     transformNativeLibsWithStripDebugSymbolForRelease << {
         copy{
-            from new File(project.buildDir, "intermediates/transforms/mergeJniLibs/release/folders/2000/3/main/lib")
+            from transformNativeLibsWithMergeJniLibsForRelease
             into new File(project.buildDir, "unstrippedSo")
             include '**/libweexjss.so', '**/libweexcore.so'
             eachFile {
-                it.path = "${it.relativePath.segments.first()}_${it.name}"
+                it.path = "${it.relativePath.segments[5]}_${it.name}"
             }
         }
     }


### PR DESCRIPTION
Use a dedicated way to copy unstripped `.so` file without the importable file path.
