### PR TITLE
Redirect all invocation of Android C++ log to log_defines.h

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Bridge/WXCoreBridge.mm
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXCoreBridge.mm
@@ -942,20 +942,20 @@ break; \
     
     class LogBridgeIOS: public LogBridge {
     public:
-        virtual void log(LogLevel level, const char* file, unsigned long line, const char* log) override {
+        virtual void log(LogLevel level, const char* tag, const char* file, unsigned long line, const char* log) override {
 #ifdef DEBUG
             switch (level) {
                 case LogLevel::Error:
-                    printf("<%s:Error|%s:%lu> %s\n", WEEX_CORE_LOG_TAG, file, line, log);
+                    printf("<%s:Error|%s:%lu> %s\n", tag, file, line, log);
                     break;
                 case LogLevel::Warn:
-                    printf("<%s:Warn|%s:%lu> %s\n", WEEX_CORE_LOG_TAG, file, line, log);
+                    printf("<%s:Warn|%s:%lu> %s\n", tag, file, line, log);
                     break;
                 case LogLevel::Info:
-                    printf("<%s:Info|%s:%lu> %s\n", WEEX_CORE_LOG_TAG, file, line, log);
+                    printf("<%s:Info|%s:%lu> %s\n", tag, file, line, log);
                     break;
                 case LogLevel::Debug:
-                    printf("<%s:Debug|%s:%lu> %s\n", WEEX_CORE_LOG_TAG, file, line, log);
+                    printf("<%s:Debug|%s:%lu> %s\n", tag, file, line, log);
                     break;
                 default:
                     break;

--- a/weex_core/Source/android/jsengine/wson/wson_jsc.cpp
+++ b/weex_core/Source/android/jsengine/wson/wson_jsc.cpp
@@ -33,15 +33,13 @@
 #include <wtf/HashMap.h>
 
 
+#define LOGE(format, ...) LOGE(format, ##__VA_ARGS__)
 
 #ifdef  __ANDROID__
     //#define WSON_JSC_DEBUG  true;
-    #include <android/log.h>
     #include <wtf/unicode/WTFUTF8.h>
-    #define TAG "weex"
-    #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, TAG, __VA_ARGS__)
+    #include "base/log_defines.h"
 #else
-  #define LOGE(...)  printf(__VA_ARGS__)
   #include <wtf/unicode/UTF8.h>
 #endif
 

--- a/weex_core/Source/base/android/log_utils.h
+++ b/weex_core/Source/base/android/log_utils.h
@@ -18,56 +18,5 @@
  */
 #ifndef _LOG_UTILS_H_
 #define _LOG_UTILS_H_
-
-#if !defined(__APPLE__)
-#include <android/log.h>
-#endif
-
-#define LOG_TAG "WeexCore"
-
-#if defined(__APPLE__)
-
-#define LOGE(...)    printf(__VA_ARGS__);printf("\n")
-#define LOGA(...)    printf(__VA_ARGS__);printf("\n")
-#define LOGD(...)    printf(__VA_ARGS__);printf("\n")
-
-#else
-
-#define LOGE(...)    __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
-#define LOGA(...)    __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
-#define LOGD(...)    ((void)0)//__android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
-
-#endif
-//#define DEBUG
-
-#ifdef DEBUG
-
-#if defined(__APPLE__)
-
-#define LOGV(...)     printf(__VA_ARGS__);printf("\n")
-#define LOGD(...)     printf(__VA_ARGS__);printf("\n")
-#define LOGI(...)     printf(__VA_ARGS__);printf("\n")
-#define LOGW(...)     printf(__VA_ARGS__);printf("\n")
-#define LOG_LINE LOGV("%s, %d", __func__, __LINE__)
-
-#else
-
-#define LOGV(...) 	__android_log_print(ANDROID_LOG_VERBOSE, LOG_TAG, __VA_ARGS__)
-#define LOGD(...) 	((void)0)//__android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
-#define LOGI(...) 	__android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
-#define LOGW(...) __android_log_print(ANDROID_LOG_WARN, LOG_TAG, __VA_ARGS__)
-#define LOG_LINE LOGV("%s, %d", __func__, __LINE__)
-
-#endif
-
-#else
-
-#define LOGV(...) ((void) 0)
-#define LOGD(...) ((void) 0)
-#define LOGI(...) ((void) 0)
-#define LOGW(...) ((void) 0)
-#define LOG_LINE
-
-#endif
-
+#include "base/log_defines.h"
 #endif //_LOG_UTILS_H_

--- a/weex_core/Source/base/log_defines.cpp
+++ b/weex_core/Source/base/log_defines.cpp
@@ -71,7 +71,7 @@ namespace WeexCore {
         return *this;
     }
     
-    void PrintLog(LogLevel level, const char* file, unsigned long line, const char* fmt, ...) {
+    void PrintLog(LogLevel level, const char* tag, const char* file, unsigned long line, const char* fmt, ...) {
         va_list args;
         va_start(args, fmt);
         LogFlattenHelper log(fmt, args);
@@ -87,16 +87,16 @@ namespace WeexCore {
 #ifdef __ANDROID__
             switch (level) {
                 case LogLevel::Error:
-                    __android_log_print(ANDROID_LOG_ERROR, WEEX_CORE_LOG_TAG, "%s:%lu, %s", file, line, log.str());
+                    __android_log_print(ANDROID_LOG_ERROR, tag, "%s:%lu, %s", file, line, log.str());
                     break;
                 case LogLevel::Warn:
-                    __android_log_print(ANDROID_LOG_WARN, WEEX_CORE_LOG_TAG, "%s:%lu, %s", file, line, log.str());
+                    __android_log_print(ANDROID_LOG_WARN, tag, "%s:%lu, %s", file, line, log.str());
                     break;
                 case LogLevel::Info:
-                    __android_log_print(ANDROID_LOG_INFO, WEEX_CORE_LOG_TAG, "%s:%lu, %s", file, line, log.str());
+                    __android_log_print(ANDROID_LOG_INFO, tag, "%s:%lu, %s", file, line, log.str());
                     break;
                 case LogLevel::Debug:
-                    __android_log_print(ANDROID_LOG_DEBUG, WEEX_CORE_LOG_TAG, "%s:%lu, %s", file, line, log.str());
+                    __android_log_print(ANDROID_LOG_DEBUG, tag, "%s:%lu, %s", file, line, log.str());
                     break;
                 default:
                     break;
@@ -104,16 +104,16 @@ namespace WeexCore {
 #elif __APPLE__
             switch (level) {
                 case LogLevel::Error:
-                    printf("<%s:Error|%s:%lu> %s\n", WEEX_CORE_LOG_TAG, file, line, log.str());
+                    printf("<%s:Error|%s:%lu> %s\n", tag, file, line, log.str());
                     break;
                 case LogLevel::Warn:
-                    printf("<%s:Warn|%s:%lu> %s\n", WEEX_CORE_LOG_TAG, file, line, log.str());
+                    printf("<%s:Warn|%s:%lu> %s\n", tag, file, line, log.str());
                     break;
                 case LogLevel::Info:
-                    printf("<%s:Info|%s:%lu> %s\n", WEEX_CORE_LOG_TAG, file, line, log.str());
+                    printf("<%s:Info|%s:%lu> %s\n", tag, file, line, log.str());
                     break;
                 case LogLevel::Debug:
-                    printf("<%s:Debug|%s:%lu> %s\n", WEEX_CORE_LOG_TAG, file, line, log.str());
+                    printf("<%s:Debug|%s:%lu> %s\n", tag, file, line, log.str());
                     break;
                 default:
                     break;

--- a/weex_core/Source/base/log_defines.h
+++ b/weex_core/Source/base/log_defines.h
@@ -19,6 +19,7 @@
 
 #ifndef LogDefines_h
 #define LogDefines_h
+#include <cstring>
 
 namespace WeexCore {
     
@@ -29,7 +30,7 @@ namespace WeexCore {
         Error
     };
     
-    void PrintLog(LogLevel level, const char* file, unsigned long line, const char* format, ...);
+    void PrintLog(LogLevel level, const char* tag, const char* file, unsigned long line, const char* format, ...);
     
 }
 
@@ -55,24 +56,36 @@ namespace WeexCore {
 
 #define WEEX_CORE_LOG_TAG "WeexCore"
 #define WEEX_CORE_FILENAME (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
-#define WEEX_CORE_LOG(level, format, ...)   WeexCore::PrintLog((level), WEEX_CORE_FILENAME, __LINE__, (format), ##__VA_ARGS__)
+#define WEEX_CORE_LOG(level, TAG, format, ...)   WeexCore::PrintLog((level), TAG, WEEX_CORE_FILENAME, __LINE__, (format), ##__VA_ARGS__)
 
-#define LOGE(format, ...)       WEEX_CORE_LOG(WeexCore::LogLevel::Error, format, ##__VA_ARGS__)
-#define LOGW(format, ...)       WEEX_CORE_LOG(WeexCore::LogLevel::Warn, format, ##__VA_ARGS__)
-#define LOGI(format, ...)       WEEX_CORE_LOG(WeexCore::LogLevel::Info, format, ##__VA_ARGS__)
+#define LOGE(format, ...)                WEEX_CORE_LOG(WeexCore::LogLevel::Debug, WEEX_CORE_LOG_TAG, format, ##__VA_ARGS__)
+#define LOGE_TAG(TAG, format, ...)       WEEX_CORE_LOG(WeexCore::LogLevel::Error, TAG, format, ##__VA_ARGS__)
 
 #ifdef DEBUG
 
-#define LOGD(format, ...)       WEEX_CORE_LOG(WeexCore::LogLevel::Debug, format, ##__VA_ARGS__)
+#define LOGD(format, ...)           WEEX_CORE_LOG(WeexCore::LogLevel::Debug, WEEX_CORE_LOG_TAG, format, ##__VA_ARGS__)
+#define LOGW(format, ...)           WEEX_CORE_LOG(WeexCore::LogLevel::Warn, WEEX_CORE_LOG_TAG, format, ##__VA_ARGS__)
+#define LOGI(format, ...)           WEEX_CORE_LOG(WeexCore::LogLevel::Info, WEEX_CORE_LOG_TAG, format, ##__VA_ARGS__)
+
+#define LOGD_TAG(TAG, format, ...)       WEEX_CORE_LOG(WeexCore::LogLevel::Debug, TAG, format, ##__VA_ARGS__)
+#define LOGW_TAG(TAG, format, ...)       WEEX_CORE_LOG(WeexCore::LogLevel::Warn, TAG, format, ##__VA_ARGS__)
+#define LOGI_TAG(TAG, format, ...)       WEEX_CORE_LOG(WeexCore::LogLevel::Info, TAG, format, ##__VA_ARGS__)
 
 #else
 
 #define LOGD(format, ...)       ((void) 0)
+#define LOGW(format, ...)       ((void) 0)
+#define LOGD(format, ...)       ((void) 0)
+
+#define LOGD_TAG(TAG, format, ...)       ((void) 0)
+#define LOGW_TAG(TAG, format, ...)       ((void) 0)
+#define LOGI_TAG(TAG, format, ...)       ((void) 0)
 
 #endif
 
 #define LOGV                    LOGD
 #define LOG_LINE                ((void) 0)
+#define LOGV_TAG                LOGD
 
 #ifndef DISALLOW_COPY_AND_ASSIGN
 #define DISALLOW_COPY_AND_ASSIGN(TypeName)  \

--- a/weex_core/Source/base/utils/log_utils.cpp
+++ b/weex_core/Source/base/utils/log_utils.cpp
@@ -37,30 +37,23 @@ namespace Weex{
         // }
         switch(level) {
           case 1:
-            if (mDebugMode) {
-              __android_log_print(ANDROID_LOG_VERBOSE, tag,"%s", log);
-            }
+            LOGV_TAG("jsengine", "%s", log);
             break;
           case 2:
-            __android_log_print(ANDROID_LOG_WARN, tag,"%s", log);
+            LOGW_TAG("jsengine", "%s", log);
             break;
           case 3:
-            __android_log_print(ANDROID_LOG_ERROR, tag,"%s", log);
+            LOGE_TAG("jsengine", "%s", log);
             break;
           case 4:
-            if (mDebugMode) {
-              __android_log_print(ANDROID_LOG_DEBUG, tag,"%s", log);
-            }
+            LOGD_TAG("jsengine", "%s", log);
             break;
           case 5:
-            if (mDebugMode) {
-              __android_log_print(ANDROID_LOG_INFO, tag,"%s", log);
-            }
+            LOGI_TAG("jsengine", "%s", log);
             break;
           default:
-            if (mDebugMode) {
-              __android_log_print(ANDROID_LOG_VERBOSE, tag,"%s", log);
-            }
+            LOGV_TAG("jsengine", "%s", log);
+            break;
         }
       }
 

--- a/weex_core/Source/base/utils/log_utils.h
+++ b/weex_core/Source/base/utils/log_utils.h
@@ -19,32 +19,7 @@
 #ifndef _LOG_UTILS_H_
 #define _LOG_UTILS_H_
 
-#include <android/log.h>
-
-#define LOG_TAG "jsengine"
-
-#define LOGE(...) 	__android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
-#define LOGA(...) 	((void)0)//__android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
-//#define DEBUG
-
-#ifdef DEBUG
-
-#define LOGV(...) 	__android_log_print(ANDROID_LOG_VERBOSE, LOG_TAG, __VA_ARGS__)
-#define LOGD(...) 	((void)0)//__android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
-#define LOGI(...) 	__android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
-#define LOGW(...) __android_log_print(ANDROID_LOG_WARN, LOG_TAG, __VA_ARGS__)
-#define LOG_LINE LOGV("%s, %d", __func__, __LINE__)
-
-#else
-
-#define LOGV(...) ((void) 0)
-#define LOGD(...) ((void) 0)
-#define LOGI(...) ((void) 0)
-#define LOGW(...) ((void) 0)
-//#define LOGE(...) ((void) 0)
-#define LOG_LINE
-
-#endif
+#include "base/log_defines.h"
 
 #ifndef DISALLOW_COPY_AND_ASSIGN
 #define DISALLOW_COPY_AND_ASSIGN(TypeName)  \

--- a/weex_core/Source/core/bridge/log_bridge.h
+++ b/weex_core/Source/core/bridge/log_bridge.h
@@ -25,7 +25,7 @@ namespace WeexCore {
     public:
         LogBridge() {}
         
-        virtual void log(LogLevel level, const char* file, unsigned long line, const char* log) {};
+        virtual void log(LogLevel level, const char* tag, const char* file, unsigned long line, const char* log) {};
     };
     
 }

--- a/weex_core/Source/third_party/IPC/IPCLog.h
+++ b/weex_core/Source/third_party/IPC/IPCLog.h
@@ -24,13 +24,7 @@
 
 #ifndef IPCLOG_H
 #define IPCLOG_H
-#include <android/log.h>
-#define TAG "linzj_IPC"
-#define IPC_LOGE(...) __android_log_print(ANDROID_LOG_ERROR, TAG, __VA_ARGS__)
-
-#if defined(ENABLE_IPC_DEBUG_LOG) && ENABLE_IPC_DEBUG_LOG
-#define IPC_LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, TAG, __VA_ARGS__)
-#else
-#define IPC_LOGD(...)
-#endif
+#include "../../base/log_defines.h"
+#define IPC_LOGE(format, ...) LOGE(format, ##__VA_ARGS__)
+#define IPC_LOGD(format, ...) LOGD(format, ##__VA_ARGS__)
 #endif /* IPCLOG_H */


### PR DESCRIPTION
Weex used to mix the following android log together:
* `weex_core/Source/base/android/log_utils.h`
* `weex_core/Source/android/jsengine/wson/wson_jsc.cpp`
* `weex_core/Source/base/utils/log_utils.h`
* `weex_core/Source/third_party/IPC/IPCLog.h`

Now, all android log should redirect to `weex_core/Source/base/log_defines.h`
