### PR TITLE
[Android] developers could change log level using javascript

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/WXEnvironment.java
+++ b/android/sdk/src/main/java/com/taobao/weex/WXEnvironment.java
@@ -167,7 +167,6 @@ public class WXEnvironment {
     configs.put(WXConfig.sysVersion, SYS_VERSION);
     configs.put(WXConfig.sysModel, SYS_MODEL);
     configs.put(WXConfig.weexVersion, String.valueOf(WXSDK_VERSION));
-    configs.put(WXConfig.logLevel,sLogLevel.getName());
 
     try {
       configs.put(WXConfig.layoutDirection, isLayoutDirectionRTL() ? "rtl" : "ltr");
@@ -290,7 +289,11 @@ public class WXEnvironment {
   }
 
   public static boolean isApkDebugable() {
-    if (sApplication == null) {
+    return isApkDebugable(sApplication);
+  }
+
+  public static boolean isApkDebugable(Application application) {
+    if (application == null) {
       return false;
     }
 
@@ -304,7 +307,7 @@ public class WXEnvironment {
     try {
       String debugModeConfig = getCustomOptions().get(WXConfig.debugMode);
       if (TextUtils.isEmpty(debugModeConfig)){
-        ApplicationInfo info = sApplication.getApplicationInfo();
+        ApplicationInfo info = application.getApplicationInfo();
         isApkDebug = (info.flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0;
       }else {
         isApkDebug = Boolean.valueOf(debugModeConfig);

--- a/android/sdk/src/main/java/com/taobao/weex/WXSDKEngine.java
+++ b/android/sdk/src/main/java/com/taobao/weex/WXSDKEngine.java
@@ -85,6 +85,7 @@ import com.taobao.weex.ui.component.list.WXListComponent;
 import com.taobao.weex.ui.component.list.template.WXRecyclerTemplateList;
 import com.taobao.weex.ui.component.richtext.WXRichText;
 import com.taobao.weex.ui.config.AutoScanConfigRegister;
+import com.taobao.weex.ui.module.ConsoleLogModule;
 import com.taobao.weex.ui.module.WXLocaleModule;
 import com.taobao.weex.ui.module.WXMetaModule;
 import com.taobao.weex.ui.module.WXModalUIModule;
@@ -163,14 +164,10 @@ public class WXSDKEngine implements Serializable {
       }
       long start = System.currentTimeMillis();
       WXEnvironment.sSDKInitStart = start;
-      if(WXEnvironment.isApkDebugable()){
-        WXEnvironment.sLogLevel = LogLevel.DEBUG;
+      if(WXEnvironment.isApkDebugable(application)){
+        WXEnvironment.sLogLevel = LogLevel.INFO;
       }else{
-        if(WXEnvironment.sApplication != null){
-          WXEnvironment.sLogLevel = LogLevel.WARN;
-        }else {
-          WXLogUtils.e(TAG,"WXEnvironment.sApplication is " + WXEnvironment.sApplication);
-        }
+        WXEnvironment.sLogLevel = LogLevel.WARN;
       }
       doInitInternal(application,config);
       registerApplicationOptions(application);
@@ -377,6 +374,7 @@ public class WXSDKEngine implements Serializable {
       registerModule("meta", WXMetaModule.class);
       registerModule("webSocket", WebSocketModule.class);
       registerModule("locale", WXLocaleModule.class);
+      registerModule("sdk-console-log", ConsoleLogModule.class);
     } catch (WXException e) {
       WXLogUtils.e("[WXSDKEngine] register:", e);
     }

--- a/android/sdk/src/main/java/com/taobao/weex/ui/module/ConsoleLogModule.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/module/ConsoleLogModule.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.taobao.weex.ui.module;
+
+import android.support.annotation.Nullable;
+import android.support.v4.util.ArrayMap;
+import android.text.TextUtils;
+import com.taobao.weex.WXEnvironment;
+import com.taobao.weex.annotation.JSMethod;
+import com.taobao.weex.bridge.JSCallback;
+import com.taobao.weex.common.WXModule;
+import com.taobao.weex.utils.LogLevel;
+import java.util.Map;
+
+
+public class ConsoleLogModule extends WXModule {
+
+  @JSMethod(uiThread = false)
+  public void switchLogLevel(@Nullable String logLevel, @Nullable JSCallback callback) {
+    LogLevel logLevelEnum = getLogLevel(logLevel);
+    Map<String, String> ret = new ArrayMap<>();
+    if (logLevelEnum != null) {
+      WXEnvironment.sLogLevel = logLevelEnum;
+      ret.put("status", "success");
+    } else {
+      ret.put("status", "failure");
+    }
+
+    if (callback != null) {
+      callback.invoke(ret);
+    }
+
+  }
+
+  private @Nullable LogLevel getLogLevel(@Nullable String logLevel) {
+    LogLevel logLevelEnum = null;
+    if(!TextUtils.isEmpty(logLevel)){
+      switch (logLevel){
+        case "off":
+          logLevelEnum = LogLevel.OFF;
+          break;
+        case "error":
+          logLevelEnum = LogLevel.ERROR;
+          break;
+        case "warning":
+          logLevelEnum = LogLevel.WARN;
+          break;
+        case "info":
+          logLevelEnum = LogLevel.INFO;
+          break;
+        case "debug":
+          logLevelEnum = LogLevel.DEBUG;
+          break;
+      }
+    }
+    return logLevelEnum;
+  }
+
+
+}

--- a/android/sdk/src/main/java/com/taobao/weex/utils/LogLevel.java
+++ b/android/sdk/src/main/java/com/taobao/weex/utils/LogLevel.java
@@ -24,8 +24,14 @@ import android.util.Log;
  * Created by lixinke on 16/5/11.
  */
 public enum LogLevel {
-  WTF("wtf", 0, Log.ASSERT), ERROR("error", 1, Log.ERROR), WARN("warn", 2,Log.WARN), INFO("info", 3,Log.INFO),
-  DEBUG("debug", 4,Log.DEBUG), VERBOSE("verbose", 5, Log.VERBOSE), ALL("debug", 6,Log.DEBUG),OFF("off",7,Log.DEBUG),;
+  OFF("off",7, Log.ASSERT),
+  WTF("wtf", 6, Log.ASSERT),
+  ERROR("error", 5, Log.ERROR),
+  WARN("warn", 4, Log.WARN),
+  INFO("info", 3, Log.INFO),
+  DEBUG("debug", 2, Log.DEBUG),
+  VERBOSE("verbose", 1, Log.VERBOSE),
+  ALL("all", 0, Log.VERBOSE),;
   String name;
   int value;
   int priority;

--- a/android/sdk/src/main/java/com/taobao/weex/utils/WXLogUtils.java
+++ b/android/sdk/src/main/java/com/taobao/weex/utils/WXLogUtils.java
@@ -21,9 +21,7 @@ package com.taobao.weex.utils;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
-
 import com.taobao.weex.WXEnvironment;
-
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -81,13 +79,13 @@ public class WXLogUtils {
     }
 
     if (WXEnvironment.isApkDebugable()) {
-      Log.println(level.getPriority(),tag, msg);
-      // if not debug level then print log
-      if(!level.getName().equals("debug")){
+      if(level.getValue() - WXEnvironment.sLogLevel.getValue() >= 0) {
+        Log.println(level.getPriority(), tag, msg);
         writeConsoleLog(level.getName(), msg);
       }
+      // if not debug level then print log
     }else {
-      if(level.getPriority() - LogLevel.WARN.getPriority() >=0){
+      if(level.getValue() - LogLevel.WARN.getValue() >=0 && level.getValue() - WXEnvironment.sLogLevel.getValue() >= 0){
         Log.println(level.getPriority(),tag, msg);
       }
     }
@@ -156,17 +154,6 @@ public class WXLogUtils {
             } else {
               jsLogWatcher.onJsLog(Log.DEBUG, msg);
             }
-          }
-        }
-
-        /** This log method will be invoked from jni code, so try to extract loglevel from message. **/
-        writeConsoleLog("debug", tag + ":" + msg);
-        if(msg.contains(" | __")){
-          String[] msgs=msg.split(" | __");
-          LogLevel level;
-          if( msgs!=null && msgs.length==4 && !TextUtils.isEmpty(msgs[0]) && !TextUtils.isEmpty(msgs[2])){
-            level=getLogLevel(msgs[2]);
-            return;
           }
         }
       }

--- a/weex_core/Source/base/log_defines.h
+++ b/weex_core/Source/base/log_defines.h
@@ -61,6 +61,9 @@ namespace WeexCore {
 #define LOGE_TAG(TAG, format, ...)       WEEX_CORE_LOG(WeexCore::LogLevel::Error, TAG, format, ##__VA_ARGS__)
 #define LOGE(format, ...)                LOGE_TAG(WEEX_CORE_LOG_TAG, format, ##__VA_ARGS__)
 
+#define LOGW_TAG(TAG, format, ...)       WEEX_CORE_LOG(WeexCore::LogLevel::Warn, TAG, format, ##__VA_ARGS__)
+#define LOGW(format, ...)                LOGW_TAG(WEEX_CORE_LOG_TAG, format, ##__VA_ARGS__)
+
 #define LOGI_TAG(TAG, format, ...)       WEEX_CORE_LOG(WeexCore::LogLevel::Info, TAG, format, ##__VA_ARGS__)
 #define LOGI(format, ...)                LOGI_TAG(WEEX_CORE_LOG_TAG, format, ##__VA_ARGS__)
 
@@ -69,16 +72,10 @@ namespace WeexCore {
 #define LOGD_TAG(TAG, format, ...)       WEEX_CORE_LOG(WeexCore::LogLevel::Debug, TAG, format, ##__VA_ARGS__)
 #define LOGD(format, ...)                LOGD_TAG(WEEX_CORE_LOG_TAG, format, ##__VA_ARGS__)
 
-#define LOGW_TAG(TAG, format, ...)       WEEX_CORE_LOG(WeexCore::LogLevel::Warn, TAG, format, ##__VA_ARGS__)
-#define LOGW(format, ...)                LOGW_TAG(WEEX_CORE_LOG_TAG, format, ##__VA_ARGS__)
-
 #else
 
 #define LOGD_TAG(TAG, format, ...)       ((void) 0)
 #define LOGD(format, ...)                ((void) 0)
-
-#define LOGW_TAG(TAG, format, ...)       ((void) 0)
-#define LOGW(format, ...)                ((void) 0)
 
 #endif
 


### PR DESCRIPTION
1. Add ConsoleLogModule, developers could change log using javascript. Ref demo http://editor.weex.io/vue/8fb63b977fad1bf816b9a9ad79a43fbd
1. Print log to logcat and devtool only if WXEnviroment.sLogLevel is bigger than the log being printed.
1. Change WXEnviroment.sLogLevel to INFO under debug apk, change it to WARN otherwise. Before this change WXEnvironment.sApplication was always null when initializing WXEnviroment.sLogLevel, so WXEnviroment.sLogLevel was always debug regardless it's actually debuggable or not.
1. Enable LogI no matter it's debuggable or not.
1. Change the value of LogLevel.value, which should have no influence.