### PR TITLE
[Android] Disable all log level in release app and enable log level above debug app.

### DIFF
--- a/weex_core/Source/CMakeLists.txt
+++ b/weex_core/Source/CMakeLists.txt
@@ -31,7 +31,6 @@ add_compile_options(-fexceptions)
 
 add_definitions(-DGNU_SUPPORT=1)
 add_definitions(-DJSONCPP_NO_LOCALE_SUPPORT=1)
-add_definitions(-DDEBUG=1)
 
 add_definitions(-DRENDER_LOG=0)
 add_definitions(-DPERFORMANCE_LOG=0)

--- a/weex_core/Source/android/jsengine/object/weex_global_object.cpp
+++ b/weex_core/Source/android/jsengine/object/weex_global_object.cpp
@@ -190,7 +190,7 @@ void WeexGlobalObject::initWxEnvironment(std::vector<INIT_FRAMEWORK_PARAMS *> &p
         // --------------------------------------------------------
         // add for debug mode
         if (String("debugMode") == type && String("true") == value) {
-            Weex::LogUtil::setDebugMode(true);
+            WeexCore::DebugMode = true;
         }
         // --------------------------------------------------------
 

--- a/weex_core/Source/android/wrap/wx_bridge.cpp
+++ b/weex_core/Source/android/wrap/wx_bridge.cpp
@@ -352,11 +352,6 @@ static jint InitFramework(JNIEnv* env, jobject object, jstring script,
   freeParams(params_vector);
 
   WeexCoreManager::Instance()->set_log_bridge(new LogUtils());
-  auto custom_map = WXCoreEnvironment::getInstance()->options();
-  auto search = custom_map.find("debugMode");
-  if(search != custom_map.end() && search->second == "true"){
-    WeexCore::DebugMode = true;
-  }
   return result;
 }
 

--- a/weex_core/Source/android/wrap/wx_bridge.cpp
+++ b/weex_core/Source/android/wrap/wx_bridge.cpp
@@ -352,6 +352,11 @@ static jint InitFramework(JNIEnv* env, jobject object, jstring script,
   freeParams(params_vector);
 
   WeexCoreManager::Instance()->set_log_bridge(new LogUtils());
+  auto custom_map = WXCoreEnvironment::getInstance()->options();
+  auto search = custom_map.find("debugMode");
+  if(search != custom_map.end() && search->second == "true"){
+    WeexCore::DebugMode = true;
+  }
   return result;
 }
 

--- a/weex_core/Source/base/log_defines.cpp
+++ b/weex_core/Source/base/log_defines.cpp
@@ -28,7 +28,8 @@
 #include "core/manager/weex_core_manager.h"
 
 namespace WeexCore {
-    
+    bool DebugMode = false;
+
     struct LogFlattenHelper {
         LogFlattenHelper() : mLargeBuf() {}
         LogFlattenHelper(const char *fmt, va_list args) : LogFlattenHelper() {
@@ -85,21 +86,43 @@ namespace WeexCore {
         else {
             // Log to console by default
 #ifdef __ANDROID__
-            switch (level) {
-                case LogLevel::Error:
-                    __android_log_print(ANDROID_LOG_ERROR, tag, "%s:%lu, %s", file, line, log.str());
+            if(DebugMode) {
+                switch (level) {
+                    case LogLevel::Error:
+                        __android_log_print(ANDROID_LOG_ERROR,
+                                            tag,
+                                            "%s:%lu, %s",
+                                            file,
+                                            line,
+                                            log.str());
                     break;
-                case LogLevel::Warn:
-                    __android_log_print(ANDROID_LOG_WARN, tag, "%s:%lu, %s", file, line, log.str());
+                    case LogLevel::Warn:
+                        __android_log_print(ANDROID_LOG_WARN,
+                                            tag,
+                                            "%s:%lu, %s",
+                                            file,
+                                            line,
+                                            log.str());
                     break;
-                case LogLevel::Info:
-                    __android_log_print(ANDROID_LOG_INFO, tag, "%s:%lu, %s", file, line, log.str());
+                    case LogLevel::Info:
+                        __android_log_print(ANDROID_LOG_INFO,
+                                            tag,
+                                            "%s:%lu, %s",
+                                            file,
+                                            line,
+                                            log.str());
                     break;
-                case LogLevel::Debug:
-                    __android_log_print(ANDROID_LOG_DEBUG, tag, "%s:%lu, %s", file, line, log.str());
+                    case LogLevel::Debug:
+                        __android_log_print(ANDROID_LOG_DEBUG,
+                                            tag,
+                                            "%s:%lu, %s",
+                                            file,
+                                            line,
+                                            log.str());
                     break;
-                default:
-                    break;
+                    default:
+                        break;
+                }
             }
 #elif __APPLE__
             switch (level) {

--- a/weex_core/Source/base/log_defines.h
+++ b/weex_core/Source/base/log_defines.h
@@ -31,7 +31,8 @@ namespace WeexCore {
     };
     
     void PrintLog(LogLevel level, const char* tag, const char* file, unsigned long line, const char* format, ...);
-    
+
+    extern bool DebugMode;
 }
 
 #if defined(LOGE)

--- a/weex_core/Source/base/utils/log_utils.cpp
+++ b/weex_core/Source/base/utils/log_utils.cpp
@@ -20,10 +20,6 @@
 #include "base/utils/log_utils.h"
 
 namespace Weex{
-  bool LogUtil::mDebugMode = false;
-  void LogUtil::setDebugMode(bool debug){
-    mDebugMode = debug;
-  }
   void LogUtil::ConsoleLogPrint(int level, const char* tag, const char* log) {
         // Log = 1, 
         // Warning = 2,

--- a/weex_core/Source/base/utils/log_utils.h
+++ b/weex_core/Source/base/utils/log_utils.h
@@ -29,10 +29,7 @@
 
 namespace Weex {
   class LogUtil {
-    private:
-      static bool mDebugMode;
     public:
-      static void setDebugMode(bool debug);
       static void ConsoleLogPrint(int level, const char* tag, const char* log);
   };
 }

--- a/weex_core/Source/core/config/core_environment.cpp
+++ b/weex_core/Source/core/config/core_environment.cpp
@@ -82,6 +82,8 @@ namespace WeexCore {
     mOptions.insert(std::pair<std::string, std::string>(key, value));
     if (key == "switchInteractionLog") {
       mInteractionLogSwitch = "true" == value;
+    } else if(key == "debugMode" && value == "true"){
+      WeexCore::DebugMode = true;
     }
   }
 


### PR DESCRIPTION
1. Add a variable (DebugMode) in namespace of WeexCore. Sub-process and main-process would WeexCore::DebugMode separately.
2. The default log out is enable only if WeexCore::DebugMode is true.
3. As for LOGD printed before sub-process setting WeexCore::DebugMode, just delete -DDEBUG=1 in CMAKE

This is not a final fix, just a temporary one.