### PR TITLE
[data-render] ForceRefresh before RefreshFinish in eagle

### DIFF
--- a/weex_core/Source/core/bridge/eagle_bridge.cpp
+++ b/weex_core/Source/core/bridge/eagle_bridge.cpp
@@ -144,6 +144,9 @@ namespace WeexCore {
     }
     
     int EagleBridge::WeexCoreHandler::RefreshFinish(const char* page_id, const char* task, const char* callback) {
+      WeexCore::WeexCoreManager::Instance()
+          ->getPlatformBridge()
+          ->core_side()->ForceLayout(page_id);
         return WeexCore::WeexCoreManager::Instance()
         ->getPlatformBridge()
         ->platform_side()


### PR DESCRIPTION
Make a forceLayout before RefreshFinish in eagle to make sure view & props is stable after onRefreshFinish callback.