### PR TITLE
[Danger]add milestone check

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -275,6 +275,12 @@ filesToVerifySrcHeader.forEach(filepath => {
   }
 });
 
+// check if pr bind the github milestone
+console.log("checkMileStone")
+if(!danger.github.pr.milestone){
+  console.error("current pr not bind the milestone");
+  fail("current pr not bind the milestone");
+}
 
 /*
  * try to find the appropriate reviewer according to the blame info

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -278,8 +278,7 @@ filesToVerifySrcHeader.forEach(filepath => {
 // check if pr bind the github milestone
 console.log("checkMileStone")
 if(!danger.github.pr.milestone){
-  console.error("current pr not bind the milestone");
-  fail("current pr not bind the milestone");
+  warn("current pr not bind the milestone");
 }
 
 /*


### PR DESCRIPTION
# Brief Description of the PR
add milestone check to check if the pr are binded with a milestone.
 
# Reason to add this feature
if the contributors bind PR with the current milestone when they submit PR, and also associate the ISSUE with the current milestone when is closed.the developers of the community just need to read the milestone, and they can clear  know the tasks are resolved, the ISSUE that are solved, and the PRs that are accepted in the milestone. I think it can improve the transparency of the Weex project.

# Checklist
* [] Demo
* [] Document: