### PR TITLE
[Danger]add document check

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -275,6 +275,11 @@ filesToVerifySrcHeader.forEach(filepath => {
   }
 });
 
+// check if document update:
+var pr_body = danger.github.pr.body
+if (!pr_body.match(/\[Document\]\(http.*\)/)){
+  warn("if you update the code，maybe you should update the document and add the document PR link in the PR content with the format:[Document](http://document_PR_link)")
+}
 
 /*
  * try to find the appropriate reviewer according to the blame info


### PR DESCRIPTION
# Brief Description of the PR
add document check to remind the contributors to update document when they submit a PR.

this rule check if contributor's PR content match the regex` \[Document\]\(http.*\)`,if not, the Travis CI will output the the warning message:
```
If you update the code，maybe you should update the document and add the document PR link in the PR content with the format:[Document](http://document_PR_link)
```

BTW: the message level is warning.
# Checklist
* [Document](https://github.com/apache/incubator-weex-site/pull/446)