### PR TITLE
Do not check multi thread flag when create instance

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/WXSDKInstance.java
+++ b/android/sdk/src/main/java/com/taobao/weex/WXSDKInstance.java
@@ -572,7 +572,7 @@ public class WXSDKInstance implements IWXActivityStateListener,View.OnLayoutChan
     );
     mContainerInfo.put(WXInstanceApm.KEY_PAGE_PROPERTIES_INSTANCE_TYPE,"page");
 
-    WXBridgeManager.getInstance().checkJsEngineMultiThread();
+    // WXBridgeManager.getInstance().checkJsEngineMultiThread();
     mDisableSkipFrameworkInit = isDisableSkipFrameworkInDataRender();
   }
 


### PR DESCRIPTION
JSEngine 并行渲染的开关从每次打开页面都检查生效变为应用启动时检查生效