### PR TITLE
[jsfm] Also enable the promise polyfill on Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "weex",
   "version": "0.12.2",
   "subversion": {
-    "framework": "0.29.6",
+    "framework": "0.29.7",
     "transformer": ">=0.1.5 <0.5"
   },
   "description": "A framework for building Mobile cross-platform UI",

--- a/runtime/shared/polyfill/promise.js
+++ b/runtime/shared/polyfill/promise.js
@@ -24,7 +24,7 @@ const { WXEnvironment } = global
 
 /* istanbul ignore next */
 if (typeof WXEnvironment !== 'undefined'
-  && WXEnvironment.platform === 'iOS'
+  && (WXEnvironment.platform === 'iOS' || WXEnvironment.platform === 'android')
   && !WXEnvironment.__enable_native_promise__) {
   global.Promise = undefined
 }


### PR DESCRIPTION
<!-- First of all, thank you for your contribution! 

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/apache/incubator-weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://weex.io/guide/contribute/how-to-contribute.html#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [document](https://weex.io/guide/contribute/how-to-contribute.html#contribute-code-or-document) -->


# Brief Description of the PR

Since the internal Promise API may have unpredictable behavior on some legacy Android devices, so using the js polyfill instead (as iOS does).

Modify the js framework version in package.json, since it has already been updated in #2669

<!-- # Additional content -->