### PR TITLE
[android] onloadmore of scroller is not executed when loadmoreoffset is not set

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/ui/component/WXScroller.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/component/WXScroller.java
@@ -974,14 +974,14 @@ public class WXScroller extends WXVContainer<ViewGroup> implements WXScrollViewL
     try {
       String offset = getAttrs().getLoadMoreOffset();
       if (TextUtils.isEmpty(offset)) {
-        return;
+        offset = "0";
       }
       int offsetInt = (int)WXViewUtils.getRealPxByWidth(Float.parseFloat(offset), getInstance().getInstanceViewPortWidth());
 
       int contentH = scrollView.getChildAt(0).getHeight();
       int scrollerH = scrollView.getHeight();
       int offScreenY = contentH - y - scrollerH;
-      if (offScreenY < offsetInt) {
+      if (offScreenY <= offsetInt) {
         if (WXEnvironment.isApkDebugable()) {
           WXLogUtils.d("[WXScroller-onScroll] offScreenY :" + offScreenY);
         }


### PR DESCRIPTION
# Brief Description of the PR
On the web and iOS, do not set "loadmoreoffset" can trigger the loadmore event, but not on Android.
This pr solved it.
# Checklist
* [x] [Demo](http://dotwe.org/vue/9af56f6348cf6f915e33a9131b576c2e)