### PR TITLE
[Android] Fix Android Crash in PostTaskToMsgLoop

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/bridge/RequestHandler.java
+++ b/android/sdk/src/main/java/com/taobao/weex/bridge/RequestHandler.java
@@ -86,9 +86,9 @@ public class RequestHandler {
 
   @Keep
   @CalledByNative
-  public void getBundleType(String instanceId, String content, long nativeCallback){
+  public void getBundleType(String instanceId, final String content, final long nativeCallback){
     BundType bundleType = WXBridgeManager.getInstance().getBundleType("", content);
-    String bundleTypeStr = bundleType == null ? "Others" : bundleType.toString();
+    final String bundleTypeStr = bundleType == null ? "Others" : bundleType.toString();
     WXSDKInstance instance = WXSDKManager.getInstance().getSDKInstance(instanceId);
     if ("Others".equalsIgnoreCase(bundleTypeStr) && null != instance){
       WXExceptionUtils.commitCriticalExceptionRT(
@@ -99,7 +99,12 @@ public class RequestHandler {
           null
       );
     }
-    nativeInvokeOnSuccess(nativeCallback, content, bundleTypeStr);
+    WXBridgeManager.getInstance().post(new Runnable() {
+      @Override
+      public void run() {
+        nativeInvokeOnSuccess(nativeCallback, content, bundleTypeStr);
+      }
+    });
   }
 
   class OnHttpListenerInner extends WXHttpListener {
@@ -112,9 +117,9 @@ public class RequestHandler {
 
     @Override
     public void onSuccess(WXResponse response) {
-        String script = new String(response.originalData);
+        final String script = new String(response.originalData);
         BundType bundleType = WXBridgeManager.getInstance().getBundleType("", script);
-        String bundleTypeStr = bundleType == null ? "Others" : bundleType.toString();
+        final String bundleTypeStr = bundleType == null ? "Others" : bundleType.toString();
         if ("Others".equalsIgnoreCase(bundleTypeStr) && null != getInstance()){
           WXExceptionUtils.commitCriticalExceptionRT(
               getInstance().getInstanceId(),
@@ -124,7 +129,12 @@ public class RequestHandler {
               null
           );
         }
-        nativeInvokeOnSuccess(sNativeCallback, script, bundleTypeStr);
+        WXBridgeManager.getInstance().post(new Runnable() {
+          @Override
+          public void run() {
+            nativeInvokeOnSuccess(sNativeCallback, script, bundleTypeStr);
+          }
+        });
     }
 
     @Override

--- a/android/sdk/src/main/java/com/taobao/weex/bridge/RequestHandler.java
+++ b/android/sdk/src/main/java/com/taobao/weex/bridge/RequestHandler.java
@@ -102,7 +102,12 @@ public class RequestHandler {
     WXBridgeManager.getInstance().post(new Runnable() {
       @Override
       public void run() {
-        nativeInvokeOnSuccess(nativeCallback, content, bundleTypeStr);
+        if(WXBridgeManager.getInstance().isJSFrameworkInit()) {
+          nativeInvokeOnSuccess(nativeCallback, content, bundleTypeStr);
+        }
+        else {
+          nativeInvokeOnFailed(nativeCallback);
+        }
       }
     });
   }
@@ -132,7 +137,12 @@ public class RequestHandler {
         WXBridgeManager.getInstance().post(new Runnable() {
           @Override
           public void run() {
-            nativeInvokeOnSuccess(sNativeCallback, script, bundleTypeStr);
+            if(WXBridgeManager.getInstance().isJSFrameworkInit()) {
+              nativeInvokeOnSuccess(sNativeCallback, script, bundleTypeStr);
+            }
+            else{
+              nativeInvokeOnFailed(sNativeCallback);
+            }
           }
         });
     }

--- a/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
@@ -18,6 +18,8 @@
  */
 package com.taobao.weex.bridge;
 
+import static com.taobao.weex.bridge.WXModuleManager.createDomModule;
+
 import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
@@ -32,7 +34,6 @@ import android.support.v4.util.ArrayMap;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
-
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
@@ -96,8 +97,6 @@ import com.taobao.weex.utils.WXWsonJSONSwitch;
 import com.taobao.weex.utils.batch.BactchExecutor;
 import com.taobao.weex.utils.batch.Interceptor;
 import com.taobao.weex.utils.tools.LogDetail;
-import com.taobao.weex.utils.tools.TimeCalculator;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -109,7 +108,6 @@ import java.lang.reflect.Method;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -121,8 +119,6 @@ import java.util.Stack;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-
-import static com.taobao.weex.bridge.WXModuleManager.createDomModule;
 
 /**
  * Manager class for communication between JavaScript and Android.
@@ -152,6 +148,7 @@ public class WXBridgeManager implements Callback, BactchExecutor {
   public static final String METHOD_CREATE_INSTANCE = "createInstance";
   public static final String METHOD_CREATE_PAGE_WITH_CONTENT = "CreatePageWithContent";
   public static final String METHOD_UPDATE_COMPONENT_WITH_DATA = "UpdateComponentData";
+  private static final String METHOD_POST_TASK_TO_MSG_LOOP = "PostTaskToMsgLoop";
   public static final String METHOD_DESTROY_INSTANCE = "destroyInstance";
   public static final String METHOD_CALL_JS = "callJS";
   public static final String METHOD_SET_TIMEOUT = "setTimeoutCallback";
@@ -2571,7 +2568,11 @@ public class WXBridgeManager implements Callback, BactchExecutor {
         reportErrorCode = WXErrorCode.WX_RENDER_ERR_JS_CREATE_INSTANCE;
       } else if ( METHOD_CREATE_INSTANCE_CONTEXT.equals(function) && !instance.getApmForInstance().hasAddView){
         reportErrorCode = WXErrorCode.WX_RENDER_ERR_JS_CREATE_INSTANCE_CONTEXT;
-      } else if ((METHOD_UPDATE_COMPONENT_WITH_DATA.equals(function) || METHOD_CREATE_PAGE_WITH_CONTENT.equals(function)) && !instance.getApmForInstance().hasAddView){
+      } else if (
+          (METHOD_UPDATE_COMPONENT_WITH_DATA.equals(function) ||
+          METHOD_CREATE_PAGE_WITH_CONTENT.equals(function) ||
+          METHOD_POST_TASK_TO_MSG_LOOP.equals(function) )
+          && !instance.getApmForInstance().hasAddView){
         reportErrorCode = WXErrorCode.WX_DEGRAD_EAGLE_RENDER_ERROR;
       }
       instance.onJSException(reportErrorCode.getErrorCode(), function, exception);

--- a/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
@@ -149,6 +149,7 @@ public class WXBridgeManager implements Callback, BactchExecutor {
   public static final String METHOD_CREATE_PAGE_WITH_CONTENT = "CreatePageWithContent";
   public static final String METHOD_UPDATE_COMPONENT_WITH_DATA = "UpdateComponentData";
   private static final String METHOD_POST_TASK_TO_MSG_LOOP = "PostTaskToMsgLoop";
+  private static final String METHOD_JSFM_NOT_INIT_IN_EAGLE_MODE = "JsfmNotInitInEagleMode";
   public static final String METHOD_DESTROY_INSTANCE = "destroyInstance";
   public static final String METHOD_CALL_JS = "callJS";
   public static final String METHOD_SET_TIMEOUT = "setTimeoutCallback";
@@ -2571,7 +2572,8 @@ public class WXBridgeManager implements Callback, BactchExecutor {
       } else if (
           (METHOD_UPDATE_COMPONENT_WITH_DATA.equals(function) ||
           METHOD_CREATE_PAGE_WITH_CONTENT.equals(function) ||
-          METHOD_POST_TASK_TO_MSG_LOOP.equals(function) )
+          METHOD_POST_TASK_TO_MSG_LOOP.equals(function) ||
+              METHOD_JSFM_NOT_INIT_IN_EAGLE_MODE.equals(function) )
           && !instance.getApmForInstance().hasAddView){
         reportErrorCode = WXErrorCode.WX_DEGRAD_EAGLE_RENDER_ERROR;
       }

--- a/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/bridge/WXBridgeManager.java
@@ -29,6 +29,8 @@ import android.os.Looper;
 import android.os.Message;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RestrictTo;
+import android.support.annotation.RestrictTo.Scope;
 import android.support.annotation.UiThread;
 import android.support.v4.util.ArrayMap;
 import android.text.TextUtils;
@@ -367,7 +369,8 @@ public class WXBridgeManager implements Callback, BactchExecutor {
 
   // setJSFrameworkInit and isJSFrameworkInit may use on diff thread
   // use volatile
-  private boolean isJSFrameworkInit() {
+  @RestrictTo(Scope.LIBRARY)
+  boolean isJSFrameworkInit() {
     return mInit;
   }
 

--- a/weex_core/Source/core/bridge/eagle_bridge.cpp
+++ b/weex_core/Source/core/bridge/eagle_bridge.cpp
@@ -249,10 +249,11 @@ namespace WeexCore {
         );
     }
 
+    //FIXME Please don't call this method, which will cause downgrade of Weex.
     void EagleBridge::WeexCoreHandler::PostTaskToMsgLoop(const weex::base::Closure& closure){
-#ifdef OS_ANDROID
-        WeexCoreManager::Instance()->script_thread()->message_loop()->PostTask(closure);
-#endif
+        WeexCore::WeexCoreManager::Instance()->getPlatformBridge()->platform_side()->ReportException(
+            "", "PostTaskToMsgLoop",
+            "PostTaskToMsgLoop is not supported anymore, please update to the latest version of Weex.");
     }
     
     int EagleBridge::DataRenderHandler::DestroyInstance(const char *instanceId) {

--- a/weex_core/Source/core/network/android/default_request_handler.cc
+++ b/weex_core/Source/core/network/android/default_request_handler.cc
@@ -23,6 +23,7 @@
 #include "android/base/string/scoped_jstring_utf8.h"
 #include "base/android/jniprebuild/jniheader/RequestHandler_jni.h"
 #include "base/android/jni/android_jni.h"
+#include "core/manager/weex_core_manager.h"
 
 using namespace weex::core::network;
 
@@ -44,6 +45,9 @@ static void InvokeOnFailed(JNIEnv* env, jobject jcaller, jlong callback) {
   CallbackWrapper* callback_wrapper =
       reinterpret_cast<CallbackWrapper*>(callback);
   delete callback_wrapper;
+  WeexCore::WeexCoreManager::Instance()->getPlatformBridge()->platform_side()->ReportException(
+      "", "JsfmNotInitInEagleMode",
+      "JSFramework is not initialized when executing bundle JS in eagle mode");
 }
 
 namespace weex {


### PR DESCRIPTION
[Android] Fix Android Crash in `PostTaskToMsgLoop`

As `WeexCoreManager::Instance()->script_thread()` is initialized in `WeexCore::InitFramework`, `EagleBridge::WeexCoreHandler::PostTaskToMsgLoop` will crash if `WeexCore::InitFramework` is not invoked.

Fix this problem by not supporting `EagleBridge::WeexCoreHandler::PostTaskToMsgLoop` anymore.

Stackstrace:
```
libweexcore.so (_ZN8WeexCore11EagleBridge15WeexCoreHandler17PostTaskToMsgLoopERKNSt6__ndk18functionIFvvEEE+13)
```

<!-- First of all, thank you for your contribution! 

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/apache/incubator-weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/apache/incubator-weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/apache/incubator-weex/blob/master/CONTRIBUTING.md#contribute-documentation) 
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR

# Checklist
* Demo:
* Documentation:

<!-- # Additional content -->
