### PR TITLE
[Android] Fix C++ Crash in WeexCore::NotifyLayout

### DIFF
--- a/weex_core/Source/android/wrap/wx_bridge.cpp
+++ b/weex_core/Source/android/wrap/wx_bridge.cpp
@@ -178,10 +178,13 @@ static jlongArray GetRenderFinishTime(JNIEnv* env, jobject jcaller,
 // Notice that this method is invoked from main thread.
 static jboolean NotifyLayout(JNIEnv* env, jobject jcaller, jstring instanceId) {
   if (WeexCoreManager::Instance()->getPlatformBridge()) {
+    ScopedJStringUTF8 nativeString = ScopedJStringUTF8(env, instanceId);
+    const char* c_str_instance_id = nativeString.getChars();
+    std::string std_string_nstanceId = std::string(c_str_instance_id == nullptr ? "" : c_str_instance_id);
     return WeexCoreManager::Instance()
         ->getPlatformBridge()
         ->core_side()
-        ->NotifyLayout(jString2StrFast(env, instanceId));
+        ->NotifyLayout(std_string_nstanceId);
   }
   return false;
 }


### PR DESCRIPTION
The return value of `jString2StrFast(env, instanceId)` could be `std::string(nullptr)`` if instanceId is `nullptr`, in which case the return value would cause crash.

```
    #00 pc 0x4aaec libweexcore.so (_ZNSt6__ndk16__treeINS_12__value_typeINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEPN8WeexCore14RenderPageBaseEEENS_19__map_value_compareIS7_SB_NS_4lessIS7_EELb1EEENS5_ISB_EEE13__lower_boundIS7_EENS_15__tree_iteratorISB_PNS_11__tree_nodeISB_PvEEiEERKT_SN_PNS_15__tree_end_nodeIPNS_16__tree_node_baseISL_EEEE+23)
    #01 pc 0x4aa6b libweexcore.so (_ZNSt6__ndk16__treeINS_12__value_typeINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEPN8WeexCore14RenderPageBaseEEENS_19__map_value_compareIS7_SB_NS_4lessIS7_EELb1EEENS5_ISB_EEE4findIS7_EENS_15__tree_iteratorISB_PNS_11__tree_nodeISB_PvEEiEERKT_+18)
    #02 pc 0x4907b libweexcore.so (_ZN8WeexCore13RenderManager7GetPageERKNSt6__ndk112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE+6)
    #03 pc 0x5d2d5 libweexcore.so (_ZN8WeexCore18CoreSideInPlatform12NotifyLayoutERKNSt6__ndk112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE+12)
 ```

<!-- First of all, thank you for your contribution! 

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/apache/incubator-weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/apache/incubator-weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/apache/incubator-weex/blob/master/CONTRIBUTING.md#contribute-documentation) 
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR

# Checklist
* Demo:
* Documentation:

<!-- # Additional content -->
