### PR TITLE
[Android] Fix crash in receiver.

### DIFF
--- a/android/sdk/src/main/java/com/taobao/weex/WXSDKInstance.java
+++ b/android/sdk/src/main/java/com/taobao/weex/WXSDKInstance.java
@@ -1828,10 +1828,15 @@ public class WXSDKInstance implements IWXActivityStateListener,View.OnLayoutChan
         WXSDKManager.getInstance().destroyInstance(mInstanceId);
       }
 
-      if (mGlobalEventReceiver != null) {
-        getContext().unregisterReceiver(mGlobalEventReceiver);
-        mGlobalEventReceiver = null;
+      try {
+        if (mGlobalEventReceiver != null) {
+          getContext().unregisterReceiver(mGlobalEventReceiver);
+          mGlobalEventReceiver = null;
+        }
+      }catch (IllegalArgumentException e){
+        WXLogUtils.w(WXLogUtils.getStackTrace(e));
       }
+
       if (mRootComp != null) {
         mRootComp.destroy();
         mRootComp = null;


### PR DESCRIPTION


<!-- First of all, thank you for your contribution! 

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/apache/incubator-weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/apache/incubator-weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/apache/incubator-weex/blob/master/CONTRIBUTING.md#contribute-documentation) 
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR
Fix the following crash

```
java.lang.IllegalArgumentException: Receiver not registered: com.taobao.weex.WXGlobalEventReceiver@df9ef3f
	at android.app.LoadedApk.forgetReceiverDispatcher(LoadedApk.java:1095)
	at android.app.ContextImpl.unregisterReceiver(ContextImpl.java:1500)
	at android.content.ContextWrapper.unregisterReceiver(ContextWrapper.java:608)
	at com.taobao.weex.WXSDKInstance.destroy(WXSDKInstance.java:1832)
	at com.taobao.weex.WXSDKInstance.onActivityDestroy(WXSDKInstance.java:1457)
```

# Checklist
* Demo:
* Documentation:

<!-- # Additional content -->
