### PR TITLE
Feature/try fix top native crash fd problem

### DIFF
--- a/weex_core/Source/android/bridge/multi_process_and_so_initializer.cpp
+++ b/weex_core/Source/android/bridge/multi_process_and_so_initializer.cpp
@@ -32,17 +32,17 @@
 namespace WeexCore {
 
 bool MultiProcessAndSoInitializer::Init(const std::function<void(IPCHandler*)>& OnHandlerCreated,
-                                        const std::function<bool(std::unique_ptr<WeexJSConnection>, std::unique_ptr<IPCHandler>, std::unique_ptr<IPCHandler>)>& OnInitFinished,
+                                        const std::function<bool(std::unique_ptr<WeexJSConnection>)>& OnInitFinished,
                                         const std::function<void(const char*, const char*, const char*)>& ReportException){
   bool reinit = false;
   LOGE("MultiProcessAndSoInitializer IS IN init");
 startInitFrameWork:
   try {
-    auto handler = std::move(createIPCHandler());
     auto server_handler = std::move(createIPCHandler());
     OnHandlerCreated(server_handler.get());
-    std::unique_ptr<WeexJSConnection> connection(new WeexJSConnection());
-    auto sender = connection->start(handler.get(), server_handler.get(), reinit);
+    std::unique_ptr<WeexJSConnection> connection(new WeexJSConnection(new WeexConnInfo(std::move(createIPCHandler()), true),
+        new WeexConnInfo(std::move(server_handler), false)));
+    auto sender = connection->start(reinit);
     if (sender == nullptr) {
       LOGE("JSFramwork init start sender is null");
       if (!reinit) {
@@ -52,7 +52,7 @@ startInitFrameWork:
         return false;
       }
     } else {
-      OnInitFinished(std::move(connection), std::move(handler), std::move(server_handler));
+      OnInitFinished(std::move(connection));
     }
   } catch (IPCException& e) {
     LOGE("WeexProxy catch：%s", e.msg());

--- a/weex_core/Source/android/bridge/multi_process_and_so_initializer.h
+++ b/weex_core/Source/android/bridge/multi_process_and_so_initializer.h
@@ -32,7 +32,7 @@ class MultiProcessAndSoInitializer {
   virtual ~MultiProcessAndSoInitializer() {}
 
   bool Init(const std::function<void(IPCHandler*)>&,
-            const std::function<bool(std::unique_ptr<WeexJSConnection>, std::unique_ptr<IPCHandler>, std::unique_ptr<IPCHandler>)>&,
+            const std::function<bool(std::unique_ptr<WeexJSConnection>)>&,
             const std::function<void(const char*, const char*, const char*)>&);
 };
 }  // namespace WeexCore

--- a/weex_core/Source/android/bridge/script_bridge_in_multi_process.cpp
+++ b/weex_core/Source/android/bridge/script_bridge_in_multi_process.cpp
@@ -1004,16 +1004,11 @@ ScriptBridgeInMultiProcess::ScriptBridgeInMultiProcess() {
   LOGE("ScriptBridgeInMultiProcess");
   bool passable = initializer->Init(
       [this](IPCHandler *handler) { RegisterIPCCallback(handler); },
-      [this](std::unique_ptr<WeexJSConnection> connection,
-             std::unique_ptr<IPCHandler> handler,
-             std::unique_ptr<IPCHandler> server_handler) {
+      [this](std::unique_ptr<WeexJSConnection> connection) {
         static_cast<bridge::script::ScriptSideInMultiProcess *>(script_side())
             ->set_sender(connection->sender());
         connection_ = std::move(connection);
-        handler_ = std::move(handler);
-        server_handler_ = std::move(server_handler);
-        LOGE("ScriptBridgeInMultiProcess finish %p %p", server_handler_.get(),
-             server_handler.get());
+        LOGE("ScriptBridgeInMultiProcess finish");
         return true;
       },
       [this](const char *page_id, const char *func,

--- a/weex_core/Source/android/bridge/script_bridge_in_multi_process.h
+++ b/weex_core/Source/android/bridge/script_bridge_in_multi_process.h
@@ -24,6 +24,7 @@
 
 class IPCHandler;
 class WeexJSConnection;
+class WeexConnInfo;
 class IPCHandler;
 namespace WeexCore {
 
@@ -31,13 +32,10 @@ class ScriptBridgeInMultiProcess : public ScriptBridge {
  public:
   ScriptBridgeInMultiProcess();
   ~ScriptBridgeInMultiProcess();
-
   void RegisterIPCCallback(IPCHandler *handler);
 
  private:
   std::unique_ptr<WeexJSConnection> connection_;
-  std::unique_ptr<IPCHandler> handler_;
-  std::unique_ptr<IPCHandler> server_handler_;
   DISALLOW_COPY_AND_ASSIGN(ScriptBridgeInMultiProcess);
 };
 }  // namespace WeexCore

--- a/weex_core/Source/android/multiprocess/weex_js_connection.cpp
+++ b/weex_core/Source/android/multiprocess/weex_js_connection.cpp
@@ -605,18 +605,19 @@ int copyFile(const char *SourceFile, const char *NewFile) {
 
 void *WeexConnInfo::mmap_for_ipc() {
   pid_t pid = getpid();
-  std::string clientName(this->is_client ? "WEEX_IPC_CLIENT" : "WEEX_IPC_SERVER");
-  clientName += std::to_string(pid);
+  std::string fileName(this->is_client ? "WEEX_IPC_CLIENT" : "WEEX_IPC_SERVER");
+  fileName += std::to_string(pid);
   int fd = -1;
   int initTimes = 1;
   void *base = MAP_FAILED;
   do {
-    fd = ashmem_create_region(clientName.c_str(), IPCFutexPageQueue::ipc_size);
+    fd = ashmem_create_region(fileName.c_str(), IPCFutexPageQueue::ipc_size);
     if (-1 == fd) {
       if (this->is_client) {
         throw IPCException("failed to create ashmem region: %s", strerror(errno));
       } else {
         LOGE("failed to create ashmem region: %s", strerror(errno))
+        return base;
       }
     }
     base = mmap(nullptr, IPCFutexPageQueue::ipc_size, PROT_READ | PROT_WRITE, MAP_SHARED,

--- a/weex_core/Source/android/multiprocess/weex_js_connection.h
+++ b/weex_core/Source/android/multiprocess/weex_js_connection.h
@@ -45,6 +45,10 @@ class WeexConnInfo {
   void *mmap_for_ipc();
 
   void closeFd() {
+    if(ipcFd == -1) {
+      return;
+    }
+
     if(hasBeenClosed)
       return;
     hasBeenClosed = true;

--- a/weex_core/Source/android/multiprocess/weex_js_connection.h
+++ b/weex_core/Source/android/multiprocess/weex_js_connection.h
@@ -20,21 +20,56 @@
 #define WEEXJSCONNECTION_H
 
 #include <memory>
+#include <unistd.h>
+#include <sys/mman.h>
 
 class IPCSender;
 class IPCHandler;
 
+
+class WeexConnInfo {
+ public:
+  std::unique_ptr<IPCHandler> handler;
+  int ipcFd;
+
+  WeexConnInfo(std::unique_ptr<IPCHandler> handler, bool isClient) {
+    this->handler = std::move(handler);
+    ipcFd = -1;
+    is_client = isClient;
+  }
+
+  ~WeexConnInfo() {
+    closeFd();
+  }
+
+  void *mmap_for_ipc();
+
+  void closeFd() {
+    if(hasBeenClosed)
+      return;
+    hasBeenClosed = true;
+    close(ipcFd);
+  }
+
+ private:
+  bool hasBeenClosed = false;
+  bool is_client = false;
+};
+
 class WeexJSConnection {
 public:
-    WeexJSConnection();
+    WeexJSConnection(WeexConnInfo* client, WeexConnInfo *server);
 
     ~WeexJSConnection();
 
-    IPCSender *start(IPCHandler *handler, IPCHandler *serverHandler, bool reinit);
+    IPCSender *start(bool reinit);
 
     void end();
 
     IPCSender* sender();
+
+  std::unique_ptr<WeexConnInfo> client_;
+  std::unique_ptr<WeexConnInfo> server_;
 
 private:
     struct WeexJSConnectionImpl;


### PR DESCRIPTION
1. 全局的 fd 操作改成局部变量, 每次初始化互不干扰
2. mmap 返回 9 或 13 再次尝试创建一次 fd.
3. 创建 fd 的操作放在各自的线程.
4. 创建 fd 时加上进程号, 各进程采用不同的名字. 做好隔离.