### PR TITLE
[Android] Remove duplicate receiver in manifest and remove class definition

### DIFF
--- a/android/sdk/src/main/AndroidManifest.xml
+++ b/android/sdk/src/main/AndroidManifest.xml
@@ -20,14 +20,4 @@ under the License.
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.taobao.weex">
     <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
-
-    <application>
-        <receiver
-                android:name="com.taobao.weex.WXGlobalEventReceiver"
-                android:enabled="true"
-                android:exported="false">
-        </receiver>
-
-
-    </application>
 </manifest>

--- a/android/sdk/src/main/java/com/taobao/weex/common/WXWorkThreadManager.java
+++ b/android/sdk/src/main/java/com/taobao/weex/common/WXWorkThreadManager.java
@@ -18,13 +18,21 @@
  */
 package com.taobao.weex.common;
 
+import android.support.annotation.RestrictTo;
+import android.support.annotation.RestrictTo.Scope;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 /**
- * Class for managing work thread
+ * Class for managing work thread.
+ *
+ * <p>
+ *  This class is for internal purpose,
+ *  please don't use it directly unless you know what you are doing.
+ * </p>
  */
-public final class WXWorkThreadManager {
+@RestrictTo(Scope.LIBRARY_GROUP)
+public class WXWorkThreadManager {
 
   private ExecutorService singleThreadExecutor;
 

--- a/android/sdk/src/main/java/com/taobao/weex/ui/module/WXDomModule.java
+++ b/android/sdk/src/main/java/com/taobao/weex/ui/module/WXDomModule.java
@@ -18,6 +18,8 @@
  */
 package com.taobao.weex.ui.module;
 
+import android.support.annotation.RestrictTo;
+import android.support.annotation.RestrictTo.Scope;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import com.taobao.weex.WXSDKInstance;
@@ -41,8 +43,14 @@ import com.taobao.weex.utils.WXLogUtils;
  * <p>
  *   This module is work different with other regular module, method is invoked directly, without reflection.
  * </p>
+ *
+ * <p>
+ *  This class is for internal purpose,
+ *  please don't use it directly unless you know what you are doing.
+ * </p>
  */
-public final class WXDomModule extends WXModule {
+@RestrictTo(Scope.LIBRARY_GROUP)
+public class WXDomModule extends WXModule {
 
   /** package **/
   public static final String SCROLL_TO_ELEMENT = "scrollToElement";


### PR DESCRIPTION
Remove duplicate receiver in manifest and remove class definition

* [Manifest demo](http://dotwe.org/vue/3351b6b69cac58d852ce0aef43d8eb85), work as before.
* [globalEvent Documentation](https://weex.apache.org/docs/modules/globalEvent.html#globalevent)
* As there is no `intent-filter` for the receiver in the manifest, the receiver in the manifest is useless. Actually, the receiver is registered in [code](https://github.com/apache/incubator-weex/blob/23821f9f0843a2ef14b6a7b15b0a4b3cda6afedd/android/sdk/src/main/java/com/taobao/weex/WXSDKInstance.java#L1316) with an intent.