### PR TITLE
* [Android] Change JNI string in cpp/h file

### DIFF
--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -170,7 +170,16 @@ android {
 
     externalNativeBuild {
         cmake {
-            path '../../weex_core/CMakeLists.txt'
+            if(project.useApachePackageName) {
+                path '../../weex_core/CMakeLists.txt'
+            }
+            else{
+                copy{
+                    from new File('../../weex_core/CMakeLists.txt')
+                    into new File('src/legacyRelease/cpp')
+                }
+                path 'src/legacyRelease/cpp/CMakeLists.txt'
+            }
         }
     }
 
@@ -256,4 +265,4 @@ task weex_core_license(type: com.hierynomus.gradle.license.tasks.LicenseFormat) 
                      'Source/include/JavaScriptCore/**/*.cpp'])
 }
 
-preBuild.dependsOn copyAndRenamePackage, copyManifest, copyASanLib, checkNdkVersion, licenseFormat
+preBuild.dependsOn copyAndRenameCppSourceFile, copyAndRenamePackage, copyManifest, copyASanLib, checkNdkVersion, licenseFormat

--- a/android/sdk/buildSrc/packageName.gradle
+++ b/android/sdk/buildSrc/packageName.gradle
@@ -50,6 +50,7 @@ task copyAndRenameCppSourceFile(type: Copy, dependsOn: copyOtherCppFile){
         include '**/*.cpp', '**/*.cc', '**/*.c', '**/*.h', '**/*.hpp'
         filter { String line ->
             line.replaceAll('(.*".*)(com/taobao/weex)(.*".*)', { _, prefix, packageName, suffix ->
+                logger.info("Content substation in .cpp/.h files happpened, \n Input: ${line}, \n Output: ${prefix}org/apache/weex${suffix}")
                 "${prefix}org/apache/weex${suffix}"
             })
         }

--- a/android/sdk/buildSrc/packageName.gradle
+++ b/android/sdk/buildSrc/packageName.gradle
@@ -31,3 +31,27 @@ task copyManifest(type: Copy){
         }
     }
 }
+
+task copyOtherCppFile(type: Copy){
+    if(!project.useApachePackageName) {
+        doFirst {
+            delete new File('src/legacyRelease/cpp')
+        }
+        from new File('../../weex_core')
+        into new File('src/legacyRelease/cpp')
+        exclude '**/*.cpp', '**/*.cc', '**/*.c', '**/*.h', '**/*.hpp'
+    }
+}
+
+task copyAndRenameCppSourceFile(type: Copy, dependsOn: copyOtherCppFile){
+    if(!project.useApachePackageName) {
+        from new File('../../weex_core')
+        into new File('src/legacyRelease/cpp')
+        include '**/*.cpp', '**/*.cc', '**/*.c', '**/*.h', '**/*.hpp'
+        filter { String line ->
+            line.replaceAll('(.*".*)(com/taobao/weex)(.*".*)', { _, prefix, packageName, suffix ->
+                "${prefix}org/apache/weex${suffix}"
+            })
+        }
+    }
+}


### PR DESCRIPTION
JNI string such as `com.taobao.weex` to `org.apache.weex` in cpp/h file during compiling.