### PR TITLE
[Fix ]md5 value of bundle string was set for a wrong key

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
+++ b/ios/sdk/WeexSDK/Sources/Model/WXSDKInstance.m
@@ -538,7 +538,7 @@ typedef enum : NSUInteger {
     if (!self.userInfo[@"jsMainBundleStringContentLength"]) {
         self.userInfo[@"jsMainBundleStringContentLength"] = @([mainBundleString length]);
     }
-    if (!self.userInfo[@"jsMainBundleStringContentLength"]) {
+    if (!self.userInfo[@"jsMainBundleStringContentMd5"]) {
         self.userInfo[@"jsMainBundleStringContentMd5"] = [WXUtility md5:mainBundleString];
     }
     


### PR DESCRIPTION
_renderWithMainBundleString中填写md5值时使用了错误的key

Fix issue: [#2971](https://github.com/apache/incubator-weex/issues/2971) 

<!-- First of all, thank you for your contribution! 

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/apache/incubator-weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/apache/incubator-weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/apache/incubator-weex/blob/master/CONTRIBUTING.md#contribute-documentation) 
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR

# Checklist
* Demo:
* Documentation:

<!-- # Additional content -->
