### PR TITLE
fix(jsfm): must use promise polyfill SDK version >= 0.26 fixed #3127

### DIFF
--- a/runtime/shared/polyfill/promise.js
+++ b/runtime/shared/polyfill/promise.js
@@ -24,7 +24,7 @@ const { WXEnvironment } = global
 
 /* istanbul ignore next */
 if (typeof WXEnvironment !== 'undefined'
-  && (WXEnvironment.platform === 'iOS' || WXEnvironment.platform === 'android')
-  && !WXEnvironment.__enable_native_promise__) {
+  && (WXEnvironment.platform === 'iOS' && !WXEnvironment.__enable_native_promise__)
+  || WXEnvironment.platform === 'android') {
   global.Promise = undefined
 }


### PR DESCRIPTION
<!-- First of all, thank you for your contribution! 

All PRs should be submitted to master branch -->

<!-- Please follow the template below:
* If you are going to fix a bug of Weex, check whether it already exists in [Github Issue](https://github.com/apache/incubator-weex/issues). If it exists, make sure to write down the link to the corresponding Github issue in the PR you are going to create.
* If you are going to add a feature for weex, reference the following recommend procedure:
    1. Writing a email to [mailing list](https://github.com/apache/incubator-weex/blob/master/CONTRIBUTING.md#mailing-list) to talk about what you'd like to do.
    1. Write the corresponding [Documentation](https://github.com/apache/incubator-weex/blob/master/CONTRIBUTING.md#contribute-documentation) 
    1. Write the corresponding Changelogs at the end of changelog.md -->


# Brief Description of the PR
Sdk >= 0.26  Android must always use polyfill.
read two commits: 
1. [[jsfm] Also enable the promise polyfill on Android](https://github.com/apache/incubator-weex/commit/eae533c5a07755c7040efff10fa51e122d997715)
2. [ [Android] Remove shared library from binary of Weex
](https://github.com/apache/incubator-weex/pull/2940/commits/89ec540930e64d6e0ec9655cb1b68c7f347b7d14#diff-5dc6ea1ced532ecf20c2aedd6eab39ddL96)

first commit let promise use polyfill in android, but second commit make `WXEnvironment.__enable_native_promise__ ` true, so promise use native, and has some unexpected behavior.

# Checklist
* Demo: 
* Documentation:

<!-- # Additional content -->
Look at this issue #3127  ,  I think to change this logic is the minimum cost 