### PR TITLE
[iOS] 修复使用 Xcode 12 构建且运行在 iOS 14 上时图片不加载的问题

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Component/WXImageComponent.m
+++ b/ios/sdk/WeexSDK/Sources/Component/WXImageComponent.m
@@ -36,19 +36,6 @@
 #import "WXMonitor.h"
 #import "WXSDKInstance_performance.h"
 
-@interface WXImageView : UIImageView
-
-@end
-
-@implementation WXImageView
-
-+ (Class)layerClass
-{
-    return [WXLayer class];
-}
-
-@end
-
 static dispatch_queue_t WXImageUpdateQueue;
 
 @interface WXImageComponent ()
@@ -235,7 +222,7 @@ WX_EXPORT_METHOD(@selector(save:))
 
 - (UIView *)loadView
 {
-    return [[WXImageView alloc] init];
+    return [[UIImageView alloc] init];
 }
 
 - (void)addEvent:(NSString *)eventName {


### PR DESCRIPTION
# Brief Description of the PR

直接触发问题的地方大致是在[这里](https://github.com/apache/incubator-weex/blob/master/ios/sdk/WeexSDK/Sources/Component/WXImageComponent.m#L601)。

之前，设置 `UIImageView` 的 `image` 属性之后，系统会直接更新 `layer.contents` ，但是在 Xcode 12 + iOS 14 之后，系统不会立即更新 `layer.contents`，而是会在合适的时机（可能是去调用 `-display` 方法）去更新视图。我们这里把 `layerClass` 改了，重写了 `-display` 且没有调用父类的实现，就造成在这种情况下永远不会更新视图了。

修复的方法可以是为 `WXImageView` 单独配置一个 `WXLayer` 的子类作为 `layerClass`，在这个子类的 `-display` 实现里面，针对 Xcode 12 + iOS 14 这种情况，手动调用 `WXLayer` 父类（也就是 `CALayer`）的 `-display` 方法。

但是仔细检查代码看来，这整个 `WXImageView` 及相关覆盖应该都是没有必要存在的，于是就有了这个直接改用 `UIImageView` 的补丁。

----

Demo link: http://dotwe.org/vue/4a42a418f7531d2ece3c52d2baf7291c