### PR TITLE
[ios] callNativeModule support unicode characters

### DIFF
--- a/ios/sdk/WeexSDK/Sources/Bridge/WXCoreBridge.mm
+++ b/ios/sdk/WeexSDK/Sources/Bridge/WXCoreBridge.mm
@@ -305,7 +305,7 @@ namespace WeexCore
                     if ([object isKindOfClass:[NSDictionary class]] || [object isKindOfClass:[NSArray class]]) {
                         NSString *jsonString = [WXUtility JSONString:object];
                         returnValue->type = ParamsType::BYTEARRAYJSONSTRING;
-                        returnValue->value.byteArray = generator_bytes_array(jsonString.UTF8String, jsonString.length);
+                        returnValue->value.byteArray = generator_bytes_array(jsonString.UTF8String, [jsonString lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
                     }
                     break;
                 }


### PR DESCRIPTION
# Brief Description of the PR
前端调用Module时，如果JSON字符串中包含Unicode字符会导致解析的长度小于实际长度从而导致内容错误
