### PR TITLE
[Android] fix android component not reset clickable when remove click event

### DIFF
--- a/android/sdk/src/main/java/org/apache/weex/ui/component/WXComponent.java
+++ b/android/sdk/src/main/java/org/apache/weex/ui/component/WXComponent.java
@@ -1565,6 +1565,9 @@ public abstract class WXComponent<T extends View> extends WXBasicComponent imple
       }
       mHostClickListeners.remove(mClickEventListener);
       //click event only remove from listener array
+      if (mHostClickListeners.isEmpty()) {
+        getRealView().setClickable(false);
+      }
     }
     Scrollable scroller = getParentScroller();
     if (type.equals(Constants.Event.APPEAR) && scroller != null) {


### PR DESCRIPTION
# android component not reset clickable when remove click event

<!-- # Additional content -->
when use Vue v-if [Reusable-Element](https://vuejs.org/v2/guide/conditional.html#Controlling-Reusable-Elements-with-key) send removeEvent, android component not reset clickable cause the click event to always be consumed.